### PR TITLE
Feature/specify expanded reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- New feature to specify number of initial expanded reviews
+
 ## [2.1.0] - 2020-09-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
 - New feature to specify number of initial expanded reviews
 
 ## [2.1.0] - 2020-09-30

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,9 +34,9 @@ Once in the app's settings page, define the following settings:
 
 - **Ask For Reviewer's Location** - Checking this box activates an optional review field. Shoppers that submit reviews will be asked to fill in their current location (i.e. "Boston, MA").
 
-- **Default all review accordions to open** -  The app displays a paginated list with 10 reviews inside a collapsible accordion. Checking this box will cause *all* review accordions on the product page to default to open with review text limited to 3 lines. Reviews with more than 3 lines of text will be truncated with an ellipsis and a `Show More` link that can be used to display the whole review text.
+- **Default all review accordions to open** -  The app displays reviews on the product page inside collapsible accordions. Checking this box will cause *all* review accordions to default to open when the page is loaded, with review text limited to 3 lines. Reviews with more than 3 lines of text will be truncated with an ellipsis and a `Show More` link that can be used to display the whole review text.
 
-- **Number of open review accordions** - Checking this box allows you to set a specific number of review accordions (instead of all of them) to automatically open when the page is loaded, displaying all the review text. If the `Default all review accordions to open` is actived, this option is ignored.
+- **Number of open review accordions** - Checking this box allows you to set a specific number of review accordions (instead of all of them) to automatically open when the page is loaded, displaying all the review text. If the `Default all review accordions to open` setting is active, this option is ignored.
 
 ### Step 3 - Declaring the app's blocks in your store theme
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,17 +26,17 @@ In the account's admin dashboard, access `Apps > My Apps` and then click on th
 
 Once in the app's settings page, define the following settings:
 
-![setup-reviews-and-ratings](https://user-images.githubusercontent.com/52087100/71026561-4330e200-20e8-11ea-9f44-167cf0e77fc6.png)
+![reviews-and-ratings](https://user-images.githubusercontent.com/52087100/94868792-3df41800-041a-11eb-89a1-630cc31219cc.png)
 
-- **Allow Anonymous Reviews**: if unchecked, only logged-in shoppers will be able to review products.
+- **Allow Anonymous Reviews** - If unchecked, only logged-in shoppers will be able to review products.
 
-- **Require Admin Approval**: Checking this box activates the review moderation system. Newly submitted reviews will not be displayed on the store website until an administrator approves them in the account's admin. For more details on this, access the Modus Operandi section below.
+- **Require Admin Approval** - Checking this box activates the review moderation system. Newly submitted reviews will not be displayed on the store website until an administrator approves them in the account's admin. For more details on this, access the Modus Operandi section below.
 
-- **Ask For Reviewer's Location**: Checking this box activates an optional review field. Shoppers that submit reviews will be asked to fill in their current location (i.e. "Boston, MA").
+- **Ask For Reviewer's Location** - Checking this box activates an optional review field. Shoppers that submit reviews will be asked to fill in their current location (i.e. "Boston, MA").
 
-- **Default all review accordions to open**: Checking this box will cause all review accordions on the product page to default to open with review text limited to 3 lines. Reviews with more than 3 lines of text will be truncated with an ellipsis and a "Show More" link that can be used to display the whole review text.
+- **Default all review accordions to open** -  The app displays a paginated list with 10 reviews inside a collapsible accordion. Checking this box will cause *all* review accordions on the product page to default to open with review text limited to 3 lines. Reviews with more than 3 lines of text will be truncated with an ellipsis and a `Show More` link that can be used to display the whole review text.
 
-- **Number of open review accordions**: Select the number of review accordions on the product page to default to open. If the default all review accordions to open is active, this option is ignored.
+- **Number of open review accordions** - Checking this box allows you to set a specific number of review accordions (instead of all of them) to automatically open when the page is loaded, displaying all the review text. If the `Default all review accordions to open` is actived, this option is ignored.
 
 ### Step 3 - Declaring the app's blocks in your store theme
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ Once in the app's settings page, define the following settings:
 
 - **Default all review accordions to open**: Checking this box will cause all review accordions on the product page to default to open with review text limited to 3 lines. Reviews with more than 3 lines of text will be truncated with an ellipsis and a "Show More" link that can be used to display the whole review text.
 
+- **Number of open review accordions**: Select the number of review accordions on the product page to default to open. If the default all review accordions to open is active, this option is ignored.
+
 ### Step 3 - Declaring the app's blocks in your store theme
 
 Once the app is configured, it is time to place the following blocks in your Store Theme app:

--- a/dotnet/GraphQL/Types/AppSettingsType.cs
+++ b/dotnet/GraphQL/Types/AppSettingsType.cs
@@ -16,6 +16,7 @@ namespace ReviewsRatings.GraphQL.Types
             Field(b => b.RequireApproval).Description("Indicates whether reviews require approval.");
             Field(b => b.UseLocation).Description("Indicates whether to use Location field.");
             Field(b => b.defaultOpen).Description("Indicates whether reviews should expand by default");
+            Field(b => b.defaultOpenCount).Description("Indicates number of reviews to be expanded by default");
         }
     }
 }

--- a/dotnet/Models/AppSettings.cs
+++ b/dotnet/Models/AppSettings.cs
@@ -10,6 +10,7 @@
     /// requireApproval: Boolean
     /// useLocation: Boolean
     /// defaultOpen: Boolean
+    /// defaultOpenCount: Integer
     /// }
     /// </summary>
     public class AppSettings
@@ -18,5 +19,6 @@
         public bool RequireApproval { get; set; }
         public bool UseLocation { get; set; }
         public bool defaultOpen { get; set;}
+        public int defaultOpenCount { get; set;}
     }
 }

--- a/graphql/appSettings.graphql
+++ b/graphql/appSettings.graphql
@@ -1,5 +1,5 @@
 query AppSettings {
-  appSettings {
+  appSettings @context(provider: "vtex.reviews-and-ratings") {
     allowAnonymousReviews
     requireApproval
     useLocation

--- a/graphql/appSettings.graphql
+++ b/graphql/appSettings.graphql
@@ -4,5 +4,6 @@ query AppSettings {
     requireApproval
     useLocation
     defaultOpen
+    defaultOpenCount
   }
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -46,6 +46,7 @@ type AppSettings {
   requireApproval: Boolean
   useLocation: Boolean
   defaultOpen: Boolean
+  defaultOpenCount: Int
 }
 
 type Query {

--- a/manifest.json
+++ b/manifest.json
@@ -32,9 +32,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Reviews and Ratings",
@@ -63,6 +61,13 @@
         "description": "All review tabs on product page will default to open with review text truncated to x characters",
         "type": "boolean",
         "default": true
+      },
+      "defaultOpenCount": {
+        "title": "Number of open review accordions",
+        "description": "Specified number of review tabs on product page will default to open",
+        "type": "string",
+        "enum": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
+        "default": "0"
       }
     }
   },

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -279,30 +279,31 @@ export const ReviewForm: FC<InjectedIntlProps & Props> = ({
             })
           }
         })
-    })
-    client
-      .query({
-        query: getOrders,
-        variables: null,
-      })
-      .then((res: any) => {
-        // eslint-disable-next-line vtex/prefer-early-return
-        if (res?.data?.orders && res.data.orders.length) {
-          const hasItem = !!res.data.orders.find((order: any) => {
-            return (
-              !!order.isCompleted &&
-              !!order.items.find((item: any) => {
-                return item.productId === productId
-              })
-            )
-          })
-          if (hasItem) {
-            dispatch({
-              type: 'SET_VERIFIED',
+
+      client
+        .query({
+          query: getOrders,
+          variables: null,
+        })
+        .then((res: any) => {
+          // eslint-disable-next-line vtex/prefer-early-return
+          if (res?.data?.orders && res.data.orders.length) {
+            const hasItem = !!res.data.orders.find((order: any) => {
+              return (
+                !!order.isCompleted &&
+                !!order.items.find((item: any) => {
+                  return item.productId === productId
+                })
+              )
             })
+            if (hasItem) {
+              dispatch({
+                type: 'SET_VERIFIED',
+              })
+            }
           }
-        }
-      })
+        })
+    })
   }, [client, productId])
 
   async function submitReview() {


### PR DESCRIPTION
#### What problem is this solving?

- Allow admin to customize the number of product reviews that are initially expanded. Current implementation only allows all reviews to be expanded or none at all.
- Update to `ReviewForm.tsx` to prevent orders query when a user is not authenticated.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://expandedreviews--sandboxusdev.myvtex.com/invicta-reserve-bolt-zeus-mens-automatic-53-mm-stainless-steel-case-silver-white-dial-model-27108/p)

#### Screenshots or example usage:

![Screenshot from 2020-09-23 11-23-11](https://user-images.githubusercontent.com/22715037/94033774-4fd91980-fd8f-11ea-9cc1-98a03e7ae825.png)
![Screenshot from 2020-09-23 11-20-10](https://user-images.githubusercontent.com/22715037/94033781-51a2dd00-fd8f-11ea-9d1e-b7c3d8dc45c5.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

:partying_face: 
