### PR TITLE
Add Admin V4 navigation setup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Navigation setup for admin v4.
+
 
 ## [2.2.1] - 2020-10-27
 ### Fixed

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -1,12 +1,27 @@
-{
-  "icon": "extensions-ic",
-  "id": "98",
-  "section": "products",
-  "subSection": "catalog",
-  "subSectionItems": [
-    {
-      "labelId": "admin/reviews.title",
-      "path": "/admin/reviews-ratings/pending"
-    }
-  ]
-}
+[
+  {
+    "icon": "extensions-ic",
+    "id": "98",
+    "section": "products",
+    "subSection": "catalog",
+    "subSectionItems": [
+      {
+        "labelId": "admin/reviews.title",
+        "path": "/admin/reviews-ratings/pending"
+      }
+    ]
+  },
+  {
+    "section": "products",
+    "subSection": "catalog",
+    "LMProductId": "2",
+    "adminVersion": 4,
+    "subSectionItems": [
+      {
+        "labelId": "admin/reviews.title",
+        "path": "/admin/reviews-ratings/pending",
+        "id": "98"
+      }
+    ]
+  }
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,13 @@ Using your terminal, log in to the desired VTEX account and run the following co
 
 In the account's admin dashboard, access `Apps > My Apps` and then click on the box for `Reviews and Ratings`;
 
+on admin v3:
+
 ![apps-reviews-and-ratings](https://user-images.githubusercontent.com/52087100/71026670-77a49e00-20e8-11ea-9e01-0cb4dec12a56.png)
+
+on admin v4: 
+
+![apps-reviews-and-ratings](https://user-images.githubusercontent.com/26655596/99747634-b772c300-2ab9-11eb-927b-cd03e89421af.png)
 
 Once in the app's settings page, define the following settings:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,17 +20,15 @@ Using your terminal, log in to the desired VTEX account and run the following co
 
 ### Step 2 - Defining the app settings
 
-In the account's admin dashboard, access `Apps > My Apps` and then click on the box for `Reviews and Ratings`.
-
-- When using the admin v3:
+1. In the account's admin dashboard, access `Apps > My Apps` and then click on the box for `Reviews and Ratings`:
 
 ![apps-reviews-and-ratings](https://user-images.githubusercontent.com/52087100/71026670-77a49e00-20e8-11ea-9e01-0cb4dec12a56.png)
-
-- When using the admin v4: 
+*When using the admin v3*
 
 ![apps-reviews-and-ratings](https://user-images.githubusercontent.com/26655596/99747634-b772c300-2ab9-11eb-927b-cd03e89421af.png)
+*When using the admin v4*
 
-Once in the app's settings page, define the following settings:
+2. Once in the app's settings page, define the following settings according to the desired scenario:
 
 ![reviews-and-ratings](https://user-images.githubusercontent.com/52087100/94868792-3df41800-041a-11eb-89a1-630cc31219cc.png)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,13 +20,13 @@ Using your terminal, log in to the desired VTEX account and run the following co
 
 ### Step 2 - Defining the app settings
 
-In the account's admin dashboard, access `Apps > My Apps` and then click on the box for `Reviews and Ratings`;
+In the account's admin dashboard, access `Apps > My Apps` and then click on the box for `Reviews and Ratings`.
 
-on admin v3:
+- When using the admin v3:
 
 ![apps-reviews-and-ratings](https://user-images.githubusercontent.com/52087100/71026670-77a49e00-20e8-11ea-9e01-0cb4dec12a56.png)
 
-on admin v4: 
+- When using the admin v4: 
 
 ![apps-reviews-and-ratings](https://user-images.githubusercontent.com/26655596/99747634-b772c300-2ab9-11eb-927b-cd03e89421af.png)
 


### PR DESCRIPTION
#### What problem is this solving?

This PR setups the "Reviews" app into the new admin v4.

#### What problem is this solving?

Due to the new admin v4 release, the information architecture of the admin sidebar has completely changed. New sections were created, some old sections were deleted and many apps were moved among these sections. So, the admin-shell team had to make a bunch of refactors on builder-hub and admin-graphql. With those finished, we can now integrate all the apps into the new setup and also keep them working normally on admin v3.

#### How to test it?

1. Navigate on the sidebar and look for "Reviews" under "Products" section

[Workspace](https://newadmin--storecomponents.myvtex.com/admin)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/26655596/99744303-3239df00-2ab6-11eb-9dea-8afab8e004f7.png)
