### PR TITLE
Add new css handles to comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New css handles to review comments
+
 ## [2.4.0] - 2021-01-15
 
 ### Added

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -298,6 +298,8 @@ const CSS_HANDLES = [
   'reviewComment',
   'reviewCommentRating',
   'reviewCommentUser',
+  'reviewNameUser',
+  'reviewText',
   'graphContent',
   'graphContainer',
   'graphText',
@@ -629,37 +631,43 @@ function Reviews() {
                           {review.title}
                         </span>
                       </div>
-                      <ul className="pa0 mv2 t-small">
-                        {review.verifiedPurchaser ? (
-                          <li className="dib mr5">
-                            <IconSuccess />{' '}
-                            <FormattedMessage id="store/reviews.list.verifiedPurchaser" />
+                      <div className={`${handles.reviewNameUser}`}>
+                        <ul className="pa0 mv2 t-small">
+                          {review.verifiedPurchaser ? (
+                            <li className="dib mr5">
+                              <IconSuccess />{' '}
+                              <FormattedMessage id="store/reviews.list.verifiedPurchaser" />
+                            </li>
+                          ) : null}
+                          <li className="dib mr2">
+                            <FormattedMessage id="store/reviews.list.submitted" />{' '}
+                            <strong>{getTimeAgo(review.reviewDateTime)}</strong>
                           </li>
-                        ) : null}
-                        <li className="dib mr2">
-                          <FormattedMessage id="store/reviews.list.submitted" />{' '}
-                          <strong>{getTimeAgo(review.reviewDateTime)}</strong>
-                        </li>
-                        <li className="dib mr5">
-                          <FormattedMessage id="store/reviews.list.by" />{' '}
-                          <strong>
-                            {review.reviewerName ||
-                              intl.formatMessage(messages.anonymous)}
-                          </strong>
-                          {state.settings &&
-                            state.settings.useLocation &&
-                            review.location && <span>, {review.location}</span>}
-                        </li>
-                      </ul>
-                      <div className="t-body lh-copy mw9">
-                        <ShowMore
-                          lines={3}
-                          more="Show more"
-                          less="Show less"
-                          anchorClass=""
+                          <li className="dib mr5">
+                            <FormattedMessage id="store/reviews.list.by" />{' '}
+                            <strong>
+                              {review.reviewerName ||
+                                intl.formatMessage(messages.anonymous)}
+                            </strong>
+                            {state.settings &&
+                              state.settings.useLocation &&
+                              review.location && (
+                                <span>, {review.location}</span>
+                              )}
+                          </li>
+                        </ul>
+                        <div
+                          className={`${handles.reviewText} t-body lh-copy mw9`}
                         >
-                          {review.text}
-                        </ShowMore>
+                          <ShowMore
+                            lines={3}
+                            more="Show more"
+                            less="Show less"
+                            anchorClass=""
+                          >
+                            {review.text}
+                          </ShowMore>
+                        </div>
                       </div>
                     </div>
                   ) : (


### PR DESCRIPTION
#### What problem is this solving?

It's adding CSS handles to the title and body of review section comments and align the items

#### How to test it?

Here it is an workspace for further tests [Workspace](https://producttitle--outletespacohering.myvtex.com/calca-jeans-super-skinny-com-elastano-em-tecido-eco-denim-cintura-media-zu3m1bsn/p)

#### Screenshots or example usage:

And here it is a print showing this changes: https://ibb.co/txy1QFz

Expected Layout: https://ibb.co/ryk2fRb

Types of changes
 
- [ ] Bug fix (a non-breaking change which fixes an issue)

- [*] New feature (a non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] Requires change to documentation, which has been updated accordingly.
