### PR TITLE
Add prop position to navigation item object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Added
+## [2.6.0] - 2021-02-01
 
-### [2.6.0] - 2021-02-01
+### Added
 
 - Added prop position to v4 navigation item object in `admin/navigation.json`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Added
+
+### [2.6.0] - 2021-02-01
+
+- Added prop position to v4 navigation item object in `admin/navigation.json`
+
 ## [2.5.0] - 2021-01-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.6.0] - 2021-02-01
-
 ### Added
 
 - Added prop position to v4 navigation item object in `admin/navigation.json`

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -20,7 +20,11 @@
       {
         "labelId": "admin/reviews.title",
         "path": "/admin/reviews-ratings/pending",
-        "id": "98"
+        "id": "98",
+        "position": {
+          "index": 8,
+          "operation": "add"
+        }
       }
     ]
   }


### PR DESCRIPTION
#### What problem is this solving?
Reviews and Ratings app is not positioned in the sidebar where it should be.

#### How to test it?
Enter this [workspace](https://appsposition--recorrenciaqa.myvtex.com/admin) and open the sidebar second level in the Products section and you'll notice Reviews is second-to-last.

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/38146166/106506674-cbb74100-64a8-11eb-9d6a-54c53914b460.png)

#### Related to / Depends on
https://github.com/vtex/admin-graphql/pull/174