### PR TITLE
Add CPU spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added CPU request to service.json
+
 ## [2.7.2] - 2021-02-05
 
 ### Changed

--- a/dotnet/service.json
+++ b/dotnet/service.json
@@ -1,6 +1,10 @@
 {
   "stack": "dotnet",
   "memory": 256,
+  "cpu": {
+    "type": "shared",
+    "value": 250
+  },
   "minReplicas": 8,
   "maxReplicas": 80,
   "runtimeArgs": [


### PR DESCRIPTION


#### What problem is this solving?

This app has a high CPU consumption even when no request is being processed.
Not sure if it is something related to .NET or some background job it is performing.

Currently, each pod receives 80 mCPU and scales when consumes 95% of that.
But the background processing is more than enough to make it scale until it hits 
the max replicas cap.

This makes us consume 80 * 256 MB of memory in each cluster.
Chaging CPU request to 250 mCPU leaves us with 2 replicias each consuming 180~200m CPU.

#### How to test it?

I kindly ask that someone who develops the app helps me test it.
It shouldn't change functionality, but we need to ensure we're not breaking anything.