### PR TITLE
Fix app key / app token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,39 +6,63 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- `VtexIdClientAutCookie` header from request sent to License Manager
+- `Get_Account_By_Identifier` policy
+
 ## [2.11.4] - 2021-07-23
 
 ### Added
+
 - `Get_Account_By_Identifier` policy
-### Secutiry
+
+### Security
+
 - Removed sensitive information from log
 
 ## [2.11.3] - 2021-07-22
+
 ### Fixed
+
 - Fix path in manafest.json
+
 ## [2.11.2] - 2021-07-22
+
 ### Fixed
+
 - Fix license validate url
+
 ## [2.11.1] - 2021-07-16
+
 ### Fixed
+
 - Fix to API user validation
+
 ## [2.11.0] - 2021-07-15
+
 ### Added
 
 - `formSection`, `formBottomLine`, `formRating`, `formName`, `formLocation`, `formEmail`, `formReview`, `formSubmit`, `formInvalidMessage`, `reviewCommentMessage`, `reviewsOrderBy`, `reviewInfo`, `reviewVerifiedPurchase`, `reviewDate`, `reviewDateSubmitted`, `reviewDateValue`, `reviewAuthor`, `reviewAuthorBy`, `reviewAuthorName`, `summaryTotalReviews` and `writeReviewButton` CSS handles.
+
 ### Changed
+
 - Review details structure (author and date) from using `ul` to `div` and `span`s.
 
 ## [2.10.2] - 2021-06-02
 
 ### Fixed
+
 - Fix for anonymous review submission
 
 ## [2.10.1] - 2021-05-27
+
 ### Security
+
 - Showing sensitive information
 
 ## [2.10.0] - 2021-05-03
+
 ### Added
 
 - I18n Fr, It, Kr and Nl.
@@ -50,12 +74,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.9.2] - 2021-04-14
 
 ### Fixed
+
 - Added an `id` property to structered data
 
 ## [2.9.1] - 2021-03-16
 
 ### Fixed
+
 - CPU factor by `80`
+
 ## [2.9.0] - 2021-03-10
 
 ### Added
@@ -66,7 +93,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- I18n Jp. 
+- I18n Jp.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Removed
+### Fixed
 
-- `VtexIdClientAutCookie` header from request sent to License Manager
-- `Get_Account_By_Identifier` policy
+- When validating app key and token, first validate with VTEX ID to see if key/token pair is valid, then validate with License Manager to see if app key has access to at least one resource
 
 ## [2.11.4] - 2021-07-23
 

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -51,7 +51,7 @@ namespace ReviewsRatings.Controllers
             if (!string.IsNullOrEmpty(vtexCookie))
             {
                 validatedUser = await this._productReviewsService.ValidateUserToken(vtexCookie);
-                if(validatedUser != null)
+                if (validatedUser != null)
                 {
                     if (validatedUser.AuthStatus.Equals(AUTH_SUCCESS))
                     {
@@ -60,13 +60,13 @@ namespace ReviewsRatings.Controllers
                 }
             }
 
-            if(!string.IsNullOrEmpty(vtexAppKey) && !string.IsNullOrEmpty(vtexAppToken))
+            if (!string.IsNullOrEmpty(vtexAppKey) && !string.IsNullOrEmpty(vtexAppToken))
             {
                 string baseUrl = HttpContext.Request.Headers[FORWARDED_HOST];
                 keyAndTokenValid = await this._productReviewsService.ValidateKeyAndToken(vtexAppKey, vtexAppToken, baseUrl);
             }
 
-            if(string.IsNullOrEmpty(requestedAction))
+            if (string.IsNullOrEmpty(requestedAction))
             {
                 return BadRequest("Missing parameter");
             }
@@ -77,7 +77,7 @@ namespace ReviewsRatings.Controllers
                 switch (requestedAction)
                 {
                     case REVIEW:
-                        if (!userValidated && !keyAndTokenValid)
+                        if (!userValidated)
                         {
                             return Unauthorized("Invalid User");
                         }
@@ -105,14 +105,14 @@ namespace ReviewsRatings.Controllers
                         return Json(reviewResponse.Id);
                         break;
                     case REVIEWS:
-                        if(!keyAndTokenValid)
+                        if (!keyAndTokenValid)
                         {
                             return Unauthorized();
                         }
 
                         IList<Review> reviews = JsonConvert.DeserializeObject<IList<Review>>(bodyAsText);
                         List<int> ids = new List<int>();
-                        foreach(Review review in reviews)
+                        foreach (Review review in reviews)
                         {
                             var reviewsResponse = await this._productReviewsService.NewReview(review, false);
                             ids.Add(reviewsResponse.Id);
@@ -122,7 +122,7 @@ namespace ReviewsRatings.Controllers
                         break;
                 }
             }
-            else if("delete".Equals(HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase))
+            else if ("delete".Equals(HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase))
             {
                 int[] ids;
                 switch (requestedAction)
@@ -132,7 +132,7 @@ namespace ReviewsRatings.Controllers
                         {
                             return Json("Invalid User");
                         }
-                        
+
                         if (string.IsNullOrEmpty(id))
                         {
                             return BadRequest("Missing parameter.");
@@ -170,7 +170,7 @@ namespace ReviewsRatings.Controllers
                         break;
                 }
             }
-            else if("get".Equals(HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase))
+            else if ("get".Equals(HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase))
             {
                 var queryString = HttpContext.Request.Query;
                 var searchTerm = queryString["search_term"];
@@ -182,7 +182,7 @@ namespace ReviewsRatings.Controllers
                 switch (requestedAction)
                 {
                     case REVIEW:
-                        if(string.IsNullOrEmpty(id))
+                        if (string.IsNullOrEmpty(id))
                         {
                             return BadRequest("Missing parameter.");
                         }
@@ -225,7 +225,7 @@ namespace ReviewsRatings.Controllers
                             Data = new DataElement { data = searchData },
                             Range = new SearchRange { From = from, To = to, Total = totalCount }
                         };
-                        
+
                         return Json(searchResponse);
                         break;
                     case RATING:
@@ -237,7 +237,7 @@ namespace ReviewsRatings.Controllers
                             Average = average,
                             TotalCount = totalCount
                         };
-                        
+
                         return Json(ratingResponse);
                 }
             }

--- a/dotnet/DataSources/ProductReviewRepository.cs
+++ b/dotnet/DataSources/ProductReviewRepository.cs
@@ -261,6 +261,8 @@
             bool keyAndTokenValidated = false;
             bool keyHasAccess = false;
 
+            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
+
             if (key != null && token != null)
             {
                 ValidateKeyAndToken validateKeyAndToken = new ValidateKeyAndToken
@@ -276,6 +278,11 @@
                     RequestUri = new Uri($"http://{this._httpContextAccessor.HttpContext.Request.Headers[VTEX_ACCOUNT_HEADER_NAME]}.{ENVIRONMENT}.com.br/api/vtexid/apptoken/login"),
                     Content = new StringContent(jsonSerializedKeyAndToken, Encoding.UTF8, APPLICATION_JSON)
                 };
+
+                if (authToken != null)
+                {
+                    vtexIdRequest.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
+                }
 
                 try
                 {
@@ -299,8 +306,6 @@
                     Method = HttpMethod.Get,
                     RequestUri = new Uri($"http://licensemanager.vtexcommercestable.com.br/api/license-manager/pvt/accounts/{this._httpContextAccessor.HttpContext.Request.Headers[VTEX_ACCOUNT_HEADER_NAME]}/logins/{key}/granted")
                 };
-
-                string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
 
                 if (authToken != null)
                 {

--- a/dotnet/DataSources/ProductReviewRepository.cs
+++ b/dotnet/DataSources/ProductReviewRepository.cs
@@ -293,32 +293,32 @@
                 {
                     _context.Vtex.Logger.Error("ValidateKeyAndToken", null, $"Error validating key and token '{key}'", ex);
                 }
-            }
 
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Get,
-                RequestUri = new Uri($"http://licensemanager.vtexcommercestable.com.br/api/license-manager/pvt/accounts/{this._httpContextAccessor.HttpContext.Request.Headers[VTEX_ACCOUNT_HEADER_NAME]}/logins/{key}/granted")
-            };
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                    RequestUri = new Uri($"http://licensemanager.vtexcommercestable.com.br/api/license-manager/pvt/accounts/{this._httpContextAccessor.HttpContext.Request.Headers[VTEX_ACCOUNT_HEADER_NAME]}/logins/{key}/granted")
+                };
 
-            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
+                string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
 
-            if (authToken != null)
-            {
-                request.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
-            }
+                if (authToken != null)
+                {
+                    request.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
+                }
 
-            try
-            {
-                var client = _clientFactory.CreateClient();
-                var response = await client.SendAsync(request);
-                string responseContent = await response.Content.ReadAsStringAsync();
-                _context.Vtex.Logger.Info("ValidateKeyAccessGranted", null, $"[{response.StatusCode}] {responseContent}");
-                keyHasAccess = response.IsSuccessStatusCode && responseContent.Equals("true");
-            }
-            catch (Exception ex)
-            {
-                _context.Vtex.Logger.Error("ValidateKeyAccessGranted", null, $"Error validating access for key '{key}'", ex);
+                try
+                {
+                    var client = _clientFactory.CreateClient();
+                    var response = await client.SendAsync(request);
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    _context.Vtex.Logger.Info("ValidateKeyAccessGranted", null, $"[{response.StatusCode}] {responseContent}");
+                    keyHasAccess = response.IsSuccessStatusCode && responseContent.Equals("true");
+                }
+                catch (Exception ex)
+                {
+                    _context.Vtex.Logger.Error("ValidateKeyAccessGranted", null, $"Error validating access for key '{key}'", ex);
+                }
             }
 
             return keyAndTokenValidated && keyHasAccess;

--- a/dotnet/DataSources/ProductReviewRepository.cs
+++ b/dotnet/DataSources/ProductReviewRepository.cs
@@ -82,7 +82,7 @@
                     return null;
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _context.Vtex.Logger.Error("GetProductReviewsAsync", null, "Request Error", ex);
             }
@@ -92,12 +92,12 @@
             {
                 productReviews = JsonConvert.DeserializeObject<IList<Review>>(responseContent);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Console.WriteLine($"DeserializeObject Error: {ex.Message} ");
                 _context.Vtex.Logger.Error("GetProductReviewsAsync", null, "DeserializeObject Error", ex);
             }
-            
+
             return productReviews;
         }
 
@@ -129,7 +129,7 @@
                 string responseContent = await response.Content.ReadAsStringAsync();
                 _context.Vtex.Logger.Info("SaveProductReviewsAsync", null, $"[{response.StatusCode}] {responseContent}");
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _context.Vtex.Logger.Error("SaveProductReviewsAsync", null, "Request Error", ex);
             }
@@ -248,7 +248,7 @@
                     validatedUser = JsonConvert.DeserializeObject<ValidatedUser>(responseContent);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _context.Vtex.Logger.Error("ValidateUserToken", null, $"Error validating user token", ex);
             }
@@ -265,12 +265,6 @@
                 Method = HttpMethod.Get,
                 RequestUri = new Uri($"http://licensemanager.vtexcommercestable.com.br/api/license-manager/pvt/accounts/hosts/{baseUrl}")
             };
-
-            string authToken = this._httpContextAccessor.HttpContext.Request.Headers[HEADER_VTEX_CREDENTIAL];
-            if (authToken != null)
-            {
-                request.Headers.Add(AUTHORIZATION_HEADER_NAME, authToken);
-            }
 
             if (key != null)
             {
@@ -290,7 +284,7 @@
                 _context.Vtex.Logger.Info("ValidateKeyAndToken", null, $"[{response.StatusCode}] {responseContent}");
                 validated = response.IsSuccessStatusCode;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _context.Vtex.Logger.Error("ValidateKeyAndToken", null, $"Error validating key and token '{key}'", ex);
             }

--- a/dotnet/Models/ValidateKeyAndToken.cs
+++ b/dotnet/Models/ValidateKeyAndToken.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ReviewsRatings.Models
+{
+    public class ValidateKeyAndToken
+    {
+        public string AppKey { get; set; }
+        public string AppToken { get; set; }
+    }
+}

--- a/dotnet/Models/ValidatedKeyAndToken.cs
+++ b/dotnet/Models/ValidatedKeyAndToken.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ReviewsRatings.Models
+{
+    public class ValidatedKeyAndToken
+    {
+        public string AuthStatus { get; set; }
+        public string Token { get; set; }
+        public string Expires { get; set; }
+    }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -128,7 +128,7 @@
       "name": "outbound-access",
       "attrs": {
         "host": "{{account}}.vtexcommercestable.com.br",
-        "path": "/api/vtexid/credential/validate"
+        "path": "/api/vtexid/*"
       }
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -32,9 +32,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Reviews and Ratings",
@@ -68,19 +66,7 @@
         "title": "Number of open review accordions",
         "description": "Specified number of review tabs on product page will default to open",
         "type": "string",
-        "enum": [
-          "0",
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10"
-        ],
+        "enum": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
         "default": "0"
       },
       "showGraph": {
@@ -121,9 +107,6 @@
     },
     {
       "name": "ADMIN_DS"
-    },
-    {
-      "name": "Get_Account_By_Identifier"
     },
     {
       "name": "AcessaTodosPedidos"

--- a/manifest.json
+++ b/manifest.json
@@ -115,6 +115,9 @@
       "name": "OMSViewer"
     },
     {
+      "name": "Get_Account_By_Identifier"
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "{{account}}.vtexcommercestable.com.br",
@@ -132,7 +135,7 @@
       "name": "outbound-access",
       "attrs": {
         "host": "licensemanager.vtexcommercestable.com.br",
-        "path": "/api/license-manager/pvt/accounts/hosts/*"
+        "path": "/api/license-manager/pvt/accounts/*"
       }
     },
     {


### PR DESCRIPTION
#### What problem is this solving?

Slack thread: https://vtex.slack.com/archives/C90SGTR6U/p1627047419288900

In a nutshell, this PR uses a new authentication strategy when a user calls this app's API endpoints using a VTEX app key and app token pair as the request credentials:

First, the app key and app token are validated by VTEX ID.
Then, the app key is validated by License Manager to check if it has been granted access to at least one resource.

#### How to test it?

New version linked here: https://quotes--sandboxusdev.myvtex.com/