### PR TITLE
Add loading state to Submit Review button to prevent duplicate reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add loading state to "Submit Review" button to prevent duplicate submissions
+
 ## [2.11.5] - 2021-07-23
 
 ### Fixed

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -33,6 +33,7 @@ interface State {
   reviewSubmitted: boolean
   userAuthenticated: boolean
   alreadySubmitted: boolean
+  isSubmitting: boolean
   verifiedPurchaser: boolean
   validation: Validation
   showValidationErrors: boolean
@@ -56,6 +57,7 @@ type ReducerActions =
   | { type: 'SET_VERIFIED' }
   | { type: 'SET_ALREADY_SUBMITTED' }
   | { type: 'SET_SUBMITTED' }
+  | { type: 'SET_SUBMITTING'; args: { isSubmitting: boolean } }
   | { type: 'SHOW_VALIDATION' }
 
 const initialState = {
@@ -76,6 +78,7 @@ const initialState = {
     hasValidEmail: false,
   },
   showValidationErrors: false,
+  isSubmitting: false,
 }
 
 const reducer = (state: State, action: ReducerActions) => {
@@ -131,6 +134,11 @@ const reducer = (state: State, action: ReducerActions) => {
       return {
         ...state,
         reviewSubmitted: true,
+      }
+    case 'SET_SUBMITTING':
+      return {
+        ...state,
+        isSubmitting: action.args.isSubmitting,
       }
     case 'SET_AUTHENTICATED':
       return {
@@ -297,6 +305,10 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
   }, [client, productId])
 
   async function submitReview() {
+    dispatch({
+      type: 'SET_SUBMITTING',
+      args: { isSubmitting: true },
+    })
     if (state.validation.hasValidEmail) {
       client
         .query({
@@ -334,10 +346,18 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
           dispatch({
             type: 'SET_SUBMITTED',
           })
+          dispatch({
+            type: 'SET_SUBMITTING',
+            args: { isSubmitting: false },
+          })
         })
     } else {
       dispatch({
         type: 'SHOW_VALIDATION',
+      })
+      dispatch({
+        type: 'SET_SUBMITTING',
+        args: { isSubmitting: false },
       })
     }
   }
@@ -491,7 +511,11 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
                       <FormattedMessage id="store/reviews.form.invalid" />
                     </div>
                   )}
-                <Button variation="primary" onClick={() => submitReview()}>
+                <Button
+                  variation="primary"
+                  onClick={() => submitReview()}
+                  isLoading={state.isSubmitting}
+                >
                   <FormattedMessage id="store/reviews.form.submit" />
                 </Button>
               </Fragment>


### PR DESCRIPTION
#### What problem is this solving?

Previously, users could click the "Submit Review" button multiple times while the action was being executed, resulting in multiple review submissions. This PR adds a loading state to the button, so that it cannot be clicked again while the original action is still being executed.

#### How to test it?

Linked here: https://quotes--sandboxusdev.myvtex.com/cauliflower-fresh/p
(Ignore the duplicated review components, that's a store-theme issue)