### PR TITLE
Feature/inline empty stars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add setting to display stars in `product-rating-inline` block when the product has no reviews
+
 ## [2.11.8] - 2021-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add setting to display stars in `product-rating-inline` block when the product has no reviews
+- Use locale to format review's date in account admin view 
 
 ## [2.11.8] - 2021-08-30
 

--- a/dotnet/GraphQL/Types/AppSettingsType.cs
+++ b/dotnet/GraphQL/Types/AppSettingsType.cs
@@ -19,6 +19,7 @@ namespace ReviewsRatings.GraphQL.Types
             Field(b => b.defaultOpenCount).Description("Indicates number of reviews to be expanded by default");
             Field(b => b.showGraph).Description("Show the reviews graph on product page");
             Field(b => b.displaySummaryIfNone).Description("Display stars in product-rating-summary if there are no reviews");
+            Field(b => b.displayInlineIfNone).Description("Display stars in product-rating-inline if there are no reviews");
             Field(b => b.displaySummaryTotalReviews).Description("Display total reviews number on product-rating-summary block");
             Field(b => b.displaySummaryAddButton).Description("Display `Add review` button on product-rating-summary block");
         }

--- a/dotnet/Models/AppSettings.cs
+++ b/dotnet/Models/AppSettings.cs
@@ -13,6 +13,7 @@
     /// defaultOpenCount: Integer
     /// showGraph: Boolean
     /// displaySummaryIfNone: Boolean
+    /// displayInlineIfNone: Boolean
     /// displaySummaryTotalReviews: Boolean
     /// displaySummaryAddButton: Boolean
     /// }
@@ -26,6 +27,7 @@
         public int defaultOpenCount { get; set; }
         public bool showGraph { get; set; }
         public bool displaySummaryIfNone { get; set; }
+        public bool displayInlineIfNone { get; set; }
         public bool displaySummaryTotalReviews { get; set; }
         public bool displaySummaryAddButton { get; set; }
     }

--- a/graphql/appSettings.graphql
+++ b/graphql/appSettings.graphql
@@ -7,6 +7,7 @@ query AppSettings {
     defaultOpenCount
     showGraph
     displaySummaryIfNone
+    displayInlineIfNone
     displaySummaryTotalReviews
     displaySummaryAddButton
   }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -49,6 +49,7 @@ type AppSettings {
   defaultOpenCount: Int
   showGraph: Boolean
   displaySummaryIfNone: Boolean
+  displayInlineIfNone: Boolean
   displaySummaryTotalReviews: Boolean
   displaySummaryAddButton: Boolean
 }

--- a/manifest.json
+++ b/manifest.json
@@ -94,6 +94,11 @@
         "type": "boolean",
         "default": false
       },
+      "displayInlineIfNone": {
+        "title": "Display stars in product-rating-inline if there are no reviews",
+        "type": "boolean",
+        "default": false
+      },
       "displaySummaryTotalReviews": {
         "title": "Display total reviews number on product-rating-summary block",
         "type": "boolean",

--- a/react/RatingInline.tsx
+++ b/react/RatingInline.tsx
@@ -7,6 +7,7 @@ import { useProduct } from 'vtex.product-context'
 import Stars from './components/Stars'
 import TotalReviewsByProductId from '../graphql/totalReviewsByProductId.graphql'
 import AverageRatingByProductId from '../graphql/averageRatingByProductId.graphql'
+import AppSettings from '../graphql/appSettings.graphql'
 
 interface TotalData {
   totalReviewsByProductId: number
@@ -16,22 +17,54 @@ interface AverageData {
   averageRatingByProductId: number
 }
 
+interface SettingsData {
+  appSettings: AppSettings
+}
+
+interface AppSettings {
+  allowAnonymousReviews: boolean
+  requireApproval: boolean
+  useLocation: boolean
+  defaultOpen: boolean
+  defaultOpenCount: number
+  showGraph: boolean
+  displaySummaryIfNone: boolean
+  displayInlineIfNone: boolean
+  displaySummaryTotalReviews: boolean
+  displaySummaryAddButton: boolean
+}
+
 interface State {
   total: number
   average: number
   hasTotal: boolean
   hasAverage: boolean
+  settings: AppSettings
 }
 
 type ReducerActions =
   | { type: 'SET_TOTAL'; args: { total: number } }
   | { type: 'SET_AVERAGE'; args: { average: number } }
+  | { type: 'SET_SETTINGS'; args: { settings: AppSettings } }
+
 
 const initialState = {
   total: 0,
   average: 0,
   hasTotal: false,
   hasAverage: false,
+  settings: {
+    defaultOpen: false,
+    defaultOpenCount: 0,
+    allowAnonymousReviews: false,
+    requireApproval: true,
+    useLocation: false,
+    showGraph: false,
+    displaySummaryIfNone: false,
+    displayInlineIfNone: false,
+    displaySummaryTotalReviews: true,
+    displaySummaryAddButton: false,
+  },
 }
 
 const reducer = (state: State, action: ReducerActions) => {
@@ -47,6 +80,11 @@ const reducer = (state: State, action: ReducerActions) => {
         ...state,
         average: action.args.average,
         hasAverage: true,
+      }
+      case 'SET_SETTINGS':
+      return {
+        ...state,
+        settings: action.args.settings,
       }
     default:
       return state
@@ -82,8 +120,8 @@ function RatingInline() {
           args: { total },
         })
       })
-
-    client
+      
+      client
       .query({
         query: AverageRatingByProductId,
         variables: {
@@ -97,12 +135,25 @@ function RatingInline() {
           args: { average },
         })
       })
-  }, [client, productId])
+
+      client
+      .query({
+        query: AppSettings,
+      })
+      .then((response: ApolloQueryResult<SettingsData>) => {
+      const settings = response.data.appSettings
+      dispatch({
+        type: 'SET_SETTINGS',
+        args: { settings },
+      })
+    })
+    }, [client, productId])
+    
 
   return (
     <div className={`${handles.inlineContainer} review-summary mw8 center`}>
       {!state.hasTotal || !state.hasAverage ? null : state.total ===
-        0 ? null : (
+        0 && !state.settings.displayInlineIfNone ? null : (
         <Fragment>
           <span className="t-heading-5 v-mid">
             <Stars rating={state.average} />

--- a/react/RatingInline.tsx
+++ b/react/RatingInline.tsx
@@ -47,7 +47,6 @@ type ReducerActions =
   | { type: 'SET_AVERAGE'; args: { average: number } }
   | { type: 'SET_SETTINGS'; args: { settings: AppSettings } }
 
-
 const initialState = {
   total: 0,
   average: 0,
@@ -81,7 +80,7 @@ const reducer = (state: State, action: ReducerActions) => {
         average: action.args.average,
         hasAverage: true,
       }
-      case 'SET_SETTINGS':
+    case 'SET_SETTINGS':
       return {
         ...state,
         settings: action.args.settings,
@@ -120,8 +119,8 @@ function RatingInline() {
           args: { total },
         })
       })
-      
-      client
+
+    client
       .query({
         query: AverageRatingByProductId,
         variables: {
@@ -136,24 +135,23 @@ function RatingInline() {
         })
       })
 
-      client
+    client
       .query({
         query: AppSettings,
       })
       .then((response: ApolloQueryResult<SettingsData>) => {
-      const settings = response.data.appSettings
-      dispatch({
-        type: 'SET_SETTINGS',
-        args: { settings },
+        const settings = response.data.appSettings
+        dispatch({
+          type: 'SET_SETTINGS',
+          args: { settings },
+        })
       })
-    })
-    }, [client, productId])
-    
+  }, [client, productId])
 
   return (
     <div className={`${handles.inlineContainer} review-summary mw8 center`}>
-      {!state.hasTotal || !state.hasAverage ? null : state.total ===
-        0 && !state.settings.displayInlineIfNone ? null : (
+      {!state.hasTotal || !state.hasAverage ? null : state.total === 0 &&
+        !state.settings.displayInlineIfNone ? null : (
         <Fragment>
           <span className="t-heading-5 v-mid">
             <Stars rating={state.average} />

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -33,6 +33,7 @@ interface AppSettings {
   defaultOpenCount: number
   showGraph: boolean
   displaySummaryIfNone: boolean
+  displayInlineIfNone: boolean
   displaySummaryTotalReviews: boolean
   displaySummaryAddButton: boolean
 }
@@ -70,6 +71,7 @@ const initialState = {
     useLocation: false,
     showGraph: false,
     displaySummaryIfNone: false,
+    displayInlineIfNone: false,
     displaySummaryTotalReviews: true,
     displaySummaryAddButton: false,
   },

--- a/react/admin/ApprovedReviewsTable.tsx
+++ b/react/admin/ApprovedReviewsTable.tsx
@@ -64,7 +64,9 @@ export const ApprovedReviewsTable: FC = () => {
     } = review
 
     return {
-      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(reviewDateTime)}`,
+      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(
+        reviewDateTime
+      )}`,
       product: {
         productId,
         sku,

--- a/react/admin/ApprovedReviewsTable.tsx
+++ b/react/admin/ApprovedReviewsTable.tsx
@@ -64,7 +64,7 @@ export const ApprovedReviewsTable: FC = () => {
     } = review
 
     return {
-      date: reviewDateTime,
+      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(reviewDateTime)}`,
       product: {
         productId,
         sku,

--- a/react/admin/PendingReviewsTable.tsx
+++ b/react/admin/PendingReviewsTable.tsx
@@ -68,7 +68,7 @@ export const PendingReviewsTable: FC = () => {
     } = review
 
     return {
-      date: reviewDateTime,
+      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(reviewDateTime)}`,
       product: {
         productId,
         sku,

--- a/react/admin/PendingReviewsTable.tsx
+++ b/react/admin/PendingReviewsTable.tsx
@@ -68,7 +68,9 @@ export const PendingReviewsTable: FC = () => {
     } = review
 
     return {
-      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(reviewDateTime)}`,
+      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(
+        reviewDateTime
+      )}`,
       product: {
         productId,
         sku,


### PR DESCRIPTION
#### What problem is this solving?

- In the admin view, use locale to display the review's date.
- Add settings option to display inline empty review stars when no reviews exist.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://sdb--sandboxusdev.myvtex.com/admin/reviews-ratings/pending)
[Workspace](https://sdb--paylessqa.myvtex.com/comfort-plus-by-predictions-womens-karmen-128628/p)

#### Screenshots or example usage:

![Screenshot from 2021-09-03 15-03-47](https://user-images.githubusercontent.com/22715037/132055511-71e60e80-0c07-4751-85e8-d6c9e50b517b.png)



![Peek 2021-09-03 15-07](https://user-images.githubusercontent.com/22715037/132055521-7a03a0b6-b457-4ff9-b5f7-1d6f1d0aa6db.gif)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
