### PR TITLE
Default star rating is set to 5 when user starts writing a review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Made changes so that default star rating is 5 when user starts writing a review
+
 ## [3.2.0] - 2021-12-02
 
 ### Fixed

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -61,7 +61,7 @@ type ReducerActions =
   | { type: 'SHOW_VALIDATION' }
 
 const initialState = {
-  rating: 3,
+  rating: 5,
   title: '',
   text: '',
   location: '',


### PR DESCRIPTION
Made changes so that default star rating is 5 when user starts writing a review

#### What problem is this solving?

Made changes so that default star rating is 5 when user starts writing a review. This gives a positive impact on the users when they start writing the review.

#### Screenshots or example usage:
**_After screenshot:_**
![image](https://user-images.githubusercontent.com/86110961/144808351-f2073499-fbf9-4658-966a-6576e90dfb6f.png)

**_Before screenshot:_**
![image](https://user-images.githubusercontent.com/86110961/144808706-876bd08b-3db6-4f77-a8b2-c724cc92cffb.png)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
