### PR TITLE
[REVIEWS] bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Fix the bug for product reviews filter at store front
+
+### Fixed
+
 Fix the bug for totalReviewsByProductId query 
 
 ## [3.6.0] - 2022-02-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.6.1] - 2022-02-10
-
 ### Fixed
 
 Fix the bug for product reviews filter at store front
+
+## [3.6.1] - 2022-02-10
 
 ### Fixed
 

--- a/dotnet/Services/ProductReviewService.cs
+++ b/dotnet/Services/ProductReviewService.cs
@@ -334,25 +334,19 @@
                 searchQuery = $"{searchQuery}&approved=true";
             }
 
-            if (pastReviews)
+            if (pastReviews && !string.IsNullOrEmpty(locale))
             {
-                if (rating == 0) {
-                    wrapper = await this._productReviewRepository.GetProductReviewsMD($"productId={productId}{sort}{searchQuery}", from.ToString(), to.ToString());
-                }
-                else
+                string productQuery = $" AND productId={productId}";
+                if (rating > 0 && rating <= 5)
                 {
-                    string productQuery = $" AND productId={productId}";
-                    if (rating > 0 && rating <= 5)
-                    {
-                        ratingQuery = $" AND rating={rating}";
-                    }
-                    if (!string.IsNullOrEmpty(locale))
-                    {
-                        localeQuery = $"((locale=*{locale}-*) OR (locale is null))";
-                    }
-
-                    wrapper = await this._productReviewRepository.GetProductReviewsMD($"_where={localeQuery}{ratingQuery}{productQuery}{searchQuery}{sort}", from.ToString(), to.ToString());
+                    ratingQuery = $" AND rating={rating}";
                 }
+                if (!string.IsNullOrEmpty(locale))
+                {
+                    localeQuery = $"((locale=*{locale}-*) OR (locale is null))";
+                }
+
+                wrapper = await this._productReviewRepository.GetProductReviewsMD($"_where={localeQuery}{ratingQuery}{productQuery}{searchQuery}{sort}", from.ToString(), to.ToString());
             }
             else
             {

--- a/dotnet/Services/ProductReviewService.cs
+++ b/dotnet/Services/ProductReviewService.cs
@@ -336,15 +336,12 @@
 
             if (pastReviews && !string.IsNullOrEmpty(locale))
             {
-                string productQuery = $" AND productId={productId}";
+                localeQuery = $"((locale=*{locale}-*) OR (locale is null))";
                 if (rating > 0 && rating <= 5)
                 {
                     ratingQuery = $" AND rating={rating}";
                 }
-                if (!string.IsNullOrEmpty(locale))
-                {
-                    localeQuery = $"((locale=*{locale}-*) OR (locale is null))";
-                }
+                string productQuery = $" AND productId={productId}";
 
                 wrapper = await this._productReviewRepository.GetProductReviewsMD($"_where={localeQuery}{ratingQuery}{productQuery}{searchQuery}{sort}", from.ToString(), to.ToString());
             }


### PR DESCRIPTION
#### What problem is this solving?

bug fix for review filters

CASE1: PastReviews && locale --- use `_where=` to filter locale value OR locale is null
CASE2: 1. PastReviews && (!locale)    --- showing all reviews, so does not filter by locale
              2 (!PastReviews) && locale    --- normally filter locale, does not need `_where=` 
              3 (!PastReviews) && (!locale)--- not possible

#### How to test it?

go to any product page, and see if the average stars shows