### PR TITLE
[REVIEWS-62] Structured data rendered only if reviews > 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Structured data rendered only if reviews > 0.
+
 ## [3.7.4] - 2022-03-07
 
 ### Fixed

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -234,21 +234,23 @@ function RatingSummary() {
         <Fragment>{intl.formatMessage(messages.loadingReviews)}</Fragment>
       ) : state.total === 0 && !state.settings.displaySummaryIfNone ? null : (
         <Fragment>
-          <Helmet>
-            <script type="application/ld+json">
-              {JSON.stringify({
-                '@context': 'http://schema.org',
-                '@type': 'Product',
-                '@id': `${baseUrl}/${linkText}/p`,
-                aggregateRating: {
-                  '@type': 'AggregateRating',
-                  ratingValue: state.average.toString(),
-                  reviewCount: state.total.toString(),
-                },
-                name: productName,
-              })}
-            </script>
-          </Helmet>
+          {state.total > 0 && (
+            <Helmet>
+              <script type="application/ld+json">
+                {JSON.stringify({
+                  '@context': 'http://schema.org',
+                  '@type': 'Product',
+                  '@id': `${baseUrl}/${linkText}/p`,
+                  aggregateRating: {
+                    '@type': 'AggregateRating',
+                    ratingValue: state.average.toString(),
+                    reviewCount: state.total.toString(),
+                  },
+                  name: productName,
+                })}
+              </script>
+            </Helmet>
+          )}
           <span className="t-heading-4 v-mid">
             <Stars rating={state.average} />
           </span>{' '}


### PR DESCRIPTION
Google Search Console is penalizing PDPs SEO with values = 0 for reviewValue and reviewCount [vtex.reviews-and-ratings@2.12.6 pcbox]

SOLUTION: We decided that the ld+json structured data should only be rendered if there are actually reviews (i.e. if the total rating is > 0).