### PR TITLE
[REVIEWS-74] Use search-date field for sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use search-date field to order reviews instead reviewDateTime.
+
 ## [3.8.0] - 2022-03-11
 
 ## [3.7.5] - 2022-03-07

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -162,21 +162,25 @@ const reducer = (state: State, action: ReducerActions) => {
         ...state,
         ratingFilter: action.args.ratingFilter,
       }
+
     case 'SET_LOCALE_FILTER':
       return {
         ...state,
         localeFilter: action.args.localeFilter,
       }
+
     case 'SET_LOCALE_OPTIONS':
       return {
         ...state,
         localeOptions: action.args.localeOptions,
       }
+
     case 'SET_PASTREVIEWS':
       return {
         ...state,
         pastReviews: action.args.pastReviews,
       }
+
     case 'SET_REVIEWS':
       return {
         ...state,
@@ -374,7 +378,7 @@ function Reviews() {
   const { productId, productName, linkText } = product ?? {}
 
   const initialState = {
-    sort: 'ReviewDateTime:desc',
+    sort: 'SearchDate:desc',
     ratingFilter: 0,
     localeFilter: intl.locale.slice(0, 2),
     localeOptions: [],
@@ -405,11 +409,11 @@ function Reviews() {
   const options = [
     {
       label: intl.formatMessage(messages.sortMostRecent),
-      value: 'ReviewDateTime:desc',
+      value: 'SearchDate:desc',
     },
     {
       label: intl.formatMessage(messages.sortOldest),
-      value: 'ReviewDateTime:asc',
+      value: 'SearchDate:asc',
     },
     {
       label: intl.formatMessage(messages.sortHighestRated),
@@ -458,7 +462,9 @@ function Reviews() {
         const list = res.data.tenantInfo.bindings.map((item: any) => {
           return item.defaultLocale.slice(0, 2)
         })
+
         const localeOptions = [...new Set(list as string)]
+
         dispatch({
           type: 'SET_LOCALE_OPTIONS',
           args: { localeOptions },

--- a/react/admin/components/DownloadTable.tsx
+++ b/react/admin/components/DownloadTable.tsx
@@ -67,7 +67,7 @@ export const DownloadTable: FC<DownloadTableProps> = ({
         to,
         orderBy: sortBy
           ? `${orderByMap[sortBy]}:${sortOrder}`
-          : 'ReviewDateTime:desc',
+          : 'SearchDate:desc',
       }}
       notifyOnNetworkStatusChange
       fetchPolicy="cache-and-network"

--- a/react/admin/components/ReviewsTable.tsx
+++ b/react/admin/components/ReviewsTable.tsx
@@ -19,7 +19,7 @@ const DEFAULT_TABLE_PAGE_FROM = 0
 const DEFAULT_SORT_ORDER = 'DESC'
 
 const orderByMap: any = {
-  date: 'ReviewDateTime',
+  date: 'SearchDate',
 }
 
 interface ReviewsTableProps {
@@ -117,7 +117,7 @@ export const ReviewsTable: FC<ReviewsTableProps> = ({
         to,
         orderBy: sortBy
           ? `${orderByMap[sortBy]}:${sortOrder}`
-          : 'ReviewDateTime:desc',
+          : 'SearchDate:desc',
       }}
       notifyOnNetworkStatusChange
       fetchPolicy="cache-and-network"


### PR DESCRIPTION
The reviews sorted by date was wrong because ir was using `reviewsDateTime`, but this value is not a timestamp string date, now the app uses `searchDate` that it does.

[Workspace to test](https://arturovtexapps--minisomx.myvtex.com/admin/reviews-ratings/pending/?elements=15&from=15&sortOrder=DESC&sortedBy=date&to=30)