### PR TITLE
Fix/remove utc string to avoid invalid date

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.formatOnPaste": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Remove the UTC string to avoid returning invalid date for new Date.
+
+### Fixed
+
 - Use search-date field to order reviews instead reviewDateTime.
 
 ## [3.8.0] - 2022-03-11

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -478,7 +478,7 @@ function Reviews() {
   }))
 
   const getTimeAgo = (time: string) => {
-    const before = new Date(`${time} UTC`)
+    const before = new Date(time)
     const now = new Date()
     const diff = new Date(now.valueOf() - before.valueOf())
 


### PR DESCRIPTION
For some reason the original time of these reviews was in other format (timestamp)
So when the app go to `new Date(`${time} UTC`)` it was returning `invalid date`, so due the UTC is set by default we can remove that part of the string `new Date(time)`  and we will have the same result but avoiding invalid dates.

[Workspace to test with the original time as timestamp](https://vtexapps--jefferspet.myvtex.com/oratene-brushless-oral-care-toothpaste-gel-2-5-oz/p)
[Workspace to test with a regular original time](https://arturovtexapps--minisomx.myvtex.com/rompecabezas-pardo-polar-panda-viaje-en-carretera-we-bare-bears-1000-piezas/p)