### PR TITLE
[REVIEWS-80] Fixed newReview mutation to avoid locale equal to empty …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed newReview mutation to avoid locale equal to "".
+
 ## [3.8.5] - 2022-04-18
 
 ### Fixed

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -96,11 +96,13 @@ const reducer = (state: State, action: ReducerActions) => {
         ...state,
         location: action.args.location,
       }
+
     case 'SET_LOCALE':
       return {
         ...state,
         locale: action.args.locale,
       }
+
     case 'SET_NAME':
       return {
         ...state,
@@ -221,6 +223,7 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
   const { productId } = product ?? {}
 
   let defaultRating = 5
+
   if (settings?.defaultStarsRating !== undefined) {
     defaultRating = settings?.defaultStarsRating
   }
@@ -230,7 +233,7 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
     title: '',
     text: '',
     location: '',
-    locale: '',
+    locale: null,
     reviewerName: '',
     shopperId: '',
     reviewSubmitted: false,
@@ -375,7 +378,7 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
               title: state.title,
               text: state.text,
               reviewerName: state.reviewerName,
-              locale: state.locale,
+              locale: state.locale ?? null,
             },
           },
         })

--- a/react/admin/types/index.tsx
+++ b/react/admin/types/index.tsx
@@ -9,7 +9,7 @@ export interface Review {
   reviewerName: string
   shopperId: string
   location: string
-  locale: string
+  locale: string | null
   reviewDateTime: string
   verifiedPurchaser: boolean
   sku: string


### PR DESCRIPTION
…string

#### What problem is this solving?
Some reviews were saved with locale equal to `""` while the master data filters cannot permit filter by this specific value, so i fixed the save reviews setting `null` as default value.

#### How to test it?

You can try this cURL:
`curl --location --request GET 'http://guesscl.vtexcommercestable.com.br/api/dataentities/productReviews/search?_schema=reviewsSchema&_fields=approved,productId,title,rating,locale&_sort=searchDate DESC&_where=((locale=*es-*) OR (locale is null)) approved=false' \`

[Workspace to test](https://guesscl.myvtex.com/hombre-comfy)

