### PR TITLE
[REVIEWS-85] If adminApproval is false set approved to true when save…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-If adminApproval is false set approved to true when save review.
+
 ## [3.8.6] - 2022-04-19
 
 ### Fixed

--- a/dotnet/GraphQL/Types/ReviewInputType.cs
+++ b/dotnet/GraphQL/Types/ReviewInputType.cs
@@ -23,6 +23,7 @@ namespace ReviewsRatings.GraphQL.Types
             Field(x => x.Sku, nullable: true);
             Field(x => x.Location, nullable: true);
             Field(x => x.Locale, nullable: true);
+            Field(x => x.Approved, nullable: true);
         }
     }
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -118,6 +118,7 @@ input ReviewInput {
   reviewerName: String
   reviewDateTime: String
   sku: String
+  approved: Boolean
 }
 
 input EditReviewInput {

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -379,6 +379,7 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
               text: state.text,
               reviewerName: state.reviewerName,
               locale: state.locale ?? null,
+              approved: !settings?.requireApproval,
             },
           },
         })


### PR DESCRIPTION
If adminApproval is false set approved to true when save…

#### What problem is this solving?

If adminApproval is false set approved to true when save a review.

#### How to test it?

Save a review in the front in [this workspace](https://arturoreviews--sandboxusdev.myvtex.com/invicta-pro-diver-swiss-movement-quartz-watch---stainless-steel-case---model-0003/p) but make sure you have deactivated requiere admin approval.
Then check the reviews and ratings admin and you should see the new review in the approved tab.

[Workspace to test](https://arturoreviews--sandboxusdev.myvtex.com/invicta-pro-diver-swiss-movement-quartz-watch---stainless-steel-case---model-0003/p)
