### PR TITLE
FIX Avoid run Cypress by Dependabot

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,12 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@latest
-
-      - name: Check Chrome version
-        run: chrome --version
-
       - name: Checkout Reviews and Ratings app
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   Cypress:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Install Chrome
         uses: browser-actions/setup-chrome@latest


### PR DESCRIPTION
#### What problem is this solving?

1. Avoid wast time running tests when the PR is triggered byt GitHub Dependabot
2. Installation of Chrome removed, as the new Ubuntu image has it already