### PR TITLE
[REVIEWS-79] Render loading message before product page completely loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Render loading message before product page completely loads.
+
 ## [3.8.7] - 2022-04-21
 
 ### Fixed

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -230,7 +230,7 @@ function RatingSummary() {
 
   return (
     <div className={`${handles.summaryContainer} review-summary mw8 center`}>
-      {!state.hasTotal || !state.hasAverage ? (
+      {!productId || !state.hasTotal || !state.hasAverage ? (
         <Fragment>{intl.formatMessage(messages.loadingReviews)}</Fragment>
       ) : state.total === 0 && !state.settings.displaySummaryIfNone ? null : (
         <Fragment>


### PR DESCRIPTION
#### What problem is this solving?

The component was waiting until product Id in PDP is available to first render, now the app render the loading message before product Id is available.

[Workspace to test](https://arturoreviews--sandboxusdev.myvtex.com/invicta-pro-diver-swiss-movement-quartz-watch---stainless-steel-case---model-0003/p)