### PR TITLE
FIX GitHub Action schedule typo

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,9 +16,9 @@ on:
         description: "Choose another branch to test"
         required: true
         default: master
-    schedule:
-      # 8:00 AM UTC = 4:00 AM EDT
-      - cron: "0 8 * * *"
+  schedule:
+    # 8:00 AM UTC = 4:00 AM EDT
+    - cron: "0 8 * * *"
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
#### What problem is this solving?

Just fixing schedule tab on GitHub Actions for Cypress.