### PR TITLE
[REVIEWS-89] reviewByDateTime and reviewByDateRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Deprecate the reviewByDateTime graphQL service.
+- Set a default time to 23:59:59 in reviewByDateRange if no time received in toDate param.
+
 ## [3.8.9] - 2022-04-22
 
 ### Fixed

--- a/dotnet/DataSources/ProductReviewRepository.cs
+++ b/dotnet/DataSources/ProductReviewRepository.cs
@@ -647,6 +647,10 @@
             IList<Review> reviews = new List<Review>();
             DateTime dtFromDate = DateTime.Parse(fromDate);
             fromDate = dtFromDate.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            if (!toDate.Contains(" ")) 
+            {
+                toDate = toDate + " 23:59:59";
+            }
             DateTime dtToDate = DateTime.Parse(toDate);
             toDate = dtToDate.ToString("yyyy-MM-ddTHH:mm:ssZ");
             string total = "0";

--- a/dotnet/GraphQL/Query.cs
+++ b/dotnet/GraphQL/Query.cs
@@ -162,12 +162,16 @@ namespace ReviewsRatings.GraphQL
                 "reviewByreviewDateTime",
                 arguments: new QueryArguments(
                     new QueryArgument<NonNullGraphType<StringGraphType>> { Name = "reviewDateTime", Description = "Review DateTime" },
-                    new QueryArgument<StringGraphType> { Name = "orderBy", Description = "Order by" },
+                    new QueryArgument<IntGraphType> { Name = "from", Description = "From" },
+                    new QueryArgument<IntGraphType> { Name = "to", Description = "to" },
+                    new QueryArgument<StringGraphType> { Name = "orderBy", Description = "Order By" },
                     new QueryArgument<StringGraphType> { Name = "status", Description = "Status" }
                 ),
                 resolve: async context =>
                 {
                     string reviewDateTime = context.GetArgument<string>("reviewDateTime");
+                    int from = context.GetArgument<int>("from");
+                    int to = context.GetArgument<int>("to") + 1;
                     string orderBy = context.GetArgument<string>("orderBy");
                     string status = context.GetArgument<string>("status");
 

--- a/graphql/reviewByreviewDateTime.graphql
+++ b/graphql/reviewByreviewDateTime.graphql
@@ -1,27 +1,34 @@
 query ReviewByreviewDateTime(
   $reviewDateTime: String!
-  $offset: Int
-  $limit: Int
+  $from: Int
+  $to: Int
   $orderBy: String
   $status: String
 ) {
   reviewByreviewDateTime(
     reviewDateTime: $reviewDateTime
-    offset: $offset
-    limit: $limit
-    orderBy: $orderBy
+    from: $from,
+    to: $to,
+    orderBy: $orderBy,
     status: $status
   ) {
-    id
-    productId
-    rating
-    title
-    text
-    reviewerName
-    location
-    locale
-    shopperId
-    reviewDateTime
-    verifiedPurchaser
+    data {
+      id
+      productId
+      rating
+      title
+      text
+      reviewerName
+      location
+      locale
+      shopperId
+      reviewDateTime
+      verifiedPurchaser
+    }
+    range {
+      total
+      from
+      to
+    }
   }
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -92,6 +92,7 @@ type Query {
     orderBy: String
     status: String
   ): ReviewsResult
+    @deprecated(reason: "This query was deprecated, please use reviewByDateRange instead.")
   reviewByDateRange(
     fromDate: String!
     toDate: String!


### PR DESCRIPTION
#### What problem is this solving?

When using the `reviewByDateRange` graphQL query and you don't provide a time and the day is the same for both `fromDate` and `toDate` the default time value for `toDate` was `00:00:00`, this causes the query returns nothing because the time range is 0 seconds.

I fixed this setting `23:59:59` as default time value when the user doesn't provide a time for `toDate` variable, this way we make sure that the range will be until the last second of the day.

#### How to test it?
Use the next graphQL query and variables and comparing the results in both workspaces:
[Workspace with this fix](https://arturoreviews--sandboxusdev.myvtex.com/admin/graphql-ide)
[Workspace without this fix](https://sandboxusdev.myvtex.com/admin/graphql-ide)

### Query
```
query ReviewByDateRange(
  $fromDate: String!
  $toDate: String!
  $orderBy: String
) {
  reviewByDateRange(fromDate: $fromDate, toDate: $toDate, orderBy: $orderBy) {
    data {
      id
      productId
      rating
      title
      text
      reviewerName
      location
      locale
      reviewDateTime
      verifiedPurchaser
      sku
      approved
    }
    range {
      total
      from
      to
    }
  }
}
```

### Variables
```
{
  "fromDate": "06/02/2021",
  "toDate": "06/02/2021"
}
````
