### PR TITLE
[REVIEWS-90] [REVIEWS-91] [REVIEWS-92] Use refetch from useQuery to update the reviews list at the front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use useQuery graphQL hook to destructure refetch in Reviews component.
+- Passed refetchReviews to ReviewForm  component to refetch after a new review is saved.
+
 ## [3.8.11] - 2022-05-05
 
 ### Added

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -7,7 +7,6 @@ import { FormattedMessage, defineMessages, useIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { Card, Input, Button, Textarea } from 'vtex.styleguide'
 
-import type { Review } from './typings'
 import getOrders from './queries/orders.graphql'
 import NewReview from '../graphql/newReview.graphql'
 import HasShopperReviewed from '../graphql/hasShopperReviewed.graphql'
@@ -216,12 +215,10 @@ const CSS_HANDLES = [
 
 export function ReviewForm({
   settings,
-  reviewsDispatch,
-  reviewsState,
+  refetchReviews,
 }: {
   settings?: Partial<AppSettings>
-  reviewsDispatch?: any
-  reviewsState?: any
+  refetchReviews: any
 }) {
   const client = useApolloClient()
   const intl = useIntl()
@@ -394,46 +391,17 @@ export function ReviewForm({
         })
         .then(res => {
           if (res.data.newReview.id) {
-            const { newReview } = res.data
-            const reviews = [newReview, ...reviewsState.reviews]
-            const { total } = reviewsState
-            const graphArray = [0, 0, 0, 0, 0, 0]
-            const average =
-              reviews.reduce(
-                (acc, review) => Number(acc) + Number(review.rating),
-                0
-              ) /
-              (Number(total) + 1)
-
-            graphArray[0] = total
-
-            reviews.forEach((review: Review) => {
-              const thisRating = review.rating
-
-              graphArray[thisRating] += 1
-            })
-
-            reviewsDispatch({
-              type: 'SET_REVIEWS',
-              args: {
-                reviews: [newReview, ...reviewsState.reviews],
-                total: ++reviewsState.total,
-                graphArray,
-              },
-            })
-            reviewsDispatch({
-              type: 'SET_AVERAGE',
-              args: { average: average.toFixed(2) },
-            })
+            setTimeout(() => {
+              refetchReviews()
+              dispatch({
+                type: 'SET_SUBMITTED',
+              })
+              dispatch({
+                type: 'SET_SUBMITTING',
+                args: { isSubmitting: false },
+              })
+            }, 2000)
           }
-
-          dispatch({
-            type: 'SET_SUBMITTED',
-          })
-          dispatch({
-            type: 'SET_SUBMITTING',
-            args: { isSubmitting: false },
-          })
         })
     } else {
       dispatch({


### PR DESCRIPTION
##Use refetch from useQuery to update the reviews list at the front

#### What problem is this solving?

When someone save a new review at the front and the app settings has turned on `Allow Anonymous Reviews` and turned off `Require Admin Approval` the review was saved only at the back, but it was not visible in the front until refresh the page.

#### How to test it?
1.- Make sure you have on the settings turned on `Allow Anonymous Reviews` and turned off `Require Admin Approval` and turned on `Display graph`
2.- Go to any product and add a review.
3.- After submit the review you should see your review and the average updated as well as the reviews graph on product page.

The workspace below has already all necessary settings to test this fix.
[Workspace to test](https://arturoreviews--sandboxusdev.myvtex.com/)

