### PR TITLE
[REVIEWS-99] Show local time in the front for admin tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Convert to review date to local time in the front pending and approved tables.
+- Use IsNullOrEmpty for validations in rest APIs.
+
 ## [3.9.0] - 2022-06-02
 
 ### Added

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -83,7 +83,7 @@ namespace ReviewsRatings.Controllers
 
                         Review newReview = JsonConvert.DeserializeObject<Review>(bodyAsText);
 
-                        if(newReview.ProductId == null)
+                        if(string.IsNullOrEmpty(newReview.ProductId))
                         {
                             return BadRequest("ProductId is missing.");
                         }
@@ -91,15 +91,15 @@ namespace ReviewsRatings.Controllers
                         {
                             return BadRequest("Rating is missing.");
                         }
-                        if(newReview.Title == null)
+                        if(string.IsNullOrEmpty(newReview.Title))
                         {
                             return BadRequest("Title is missing.");
                         }
-                        if(newReview.Text == null)
+                        if(string.IsNullOrEmpty(newReview.Text))
                         {
                             return BadRequest("Text is missing.");
                         }
-                        if(newReview.ReviewerName == null)
+                        if(string.IsNullOrEmpty(newReview.ReviewerName))
                         {
                             return BadRequest("ReviewerName is missing.");
                         }
@@ -145,7 +145,7 @@ namespace ReviewsRatings.Controllers
                             {
                                 review.VerifiedPurchaser = false;
                             }
-                            if(review.ProductId == null)
+                            if(string.IsNullOrEmpty(review.ProductId))
                             {
                                 return BadRequest("ProductId is missing for one or more reviews.");
                             }
@@ -153,15 +153,15 @@ namespace ReviewsRatings.Controllers
                             {
                                 return BadRequest("Rating is missing for one or more reviews.");
                             }
-                            if(review.Title == null)
+                            if(string.IsNullOrEmpty(review.Title))
                             {
                                 return BadRequest("Title is missing for one or more reviews.");
                             }
-                            if(review.Text == null)
+                            if(string.IsNullOrEmpty(review.Text))
                             {
                                 return BadRequest("Text is missing for one or more reviews.");
                             }
-                            if(review.ReviewerName == null)
+                            if(string.IsNullOrEmpty(review.ReviewerName))
                             {
                                 return BadRequest("ReviewerName is missing for one or more reviews.");
                             }

--- a/react/admin/ApprovedReviewsTable.tsx
+++ b/react/admin/ApprovedReviewsTable.tsx
@@ -5,6 +5,7 @@ import type { IntlShape } from 'react-intl'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { Box, ToastConsumer } from 'vtex.styleguide'
 
+import { toLocalDate } from './utils/dates'
 import type {
   Review,
   ReviewTableRowData,
@@ -65,10 +66,11 @@ export const ApprovedReviewsTable: FC = () => {
       sku,
     } = review
 
+    const { formatDate, formatTime } = intl
+    const localDate = toLocalDate(reviewDateTime)
+
     return {
-      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(
-        reviewDateTime
-      )}`,
+      date: `${formatDate(localDate)} ${formatTime(localDate)}`,
       product: {
         productId,
         sku,

--- a/react/admin/PendingReviewsTable.tsx
+++ b/react/admin/PendingReviewsTable.tsx
@@ -5,6 +5,7 @@ import type { IntlShape } from 'react-intl'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { Box, ToastConsumer } from 'vtex.styleguide'
 
+import { toLocalDate } from './utils/dates'
 import type {
   Review,
   ReviewTableRowData,
@@ -69,10 +70,10 @@ export const PendingReviewsTable: FC = () => {
       sku,
     } = review
 
+    const localDate = toLocalDate(reviewDateTime)
+
     return {
-      date: `${intl.formatDate(reviewDateTime)} ${intl.formatTime(
-        reviewDateTime
-      )}`,
+      date: `${intl.formatDate(localDate)} ${intl.formatTime(localDate)}`,
       product: {
         productId,
         sku,

--- a/react/admin/utils/dates.tsx
+++ b/react/admin/utils/dates.tsx
@@ -15,3 +15,11 @@ export function currentDate() {
 
   return `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`
 }
+
+export const toLocalDate = (reviewDate: string) => {
+  const newDate = new Date(`${reviewDate} UTC`)
+  const date =
+    newDate.toString() === 'Invalid Date' ? new Date(reviewDate) : newDate
+
+  return date
+}


### PR DESCRIPTION
#### What problem is this solving?

The admin tables pending reviews and approved was showing the time in UTC format, causing a little nonconformity for the clients who wants to see the time in their local time.

#### How to test it?

You can create a new review in this workspace and see the time of your new review at the admin

[Workspace to test](https://arturoreviews--sandboxusdev.myvtex.com/admin/reviews-ratings/approved/)
