### PR TITLE
Improve GraphQL caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust GraphQL caching
+
 ## [3.10.9] - 2022-09-07
 
 ### Fixed

--- a/dotnet/Models/VtexOrder.cs
+++ b/dotnet/Models/VtexOrder.cs
@@ -488,7 +488,7 @@ namespace ReviewsRatings.Models
         public string MeasurementUnit { get; set; }
 
         [JsonProperty("unitMultiplier")]
-        public long UnitMultiplier { get; set; }
+        public long? UnitMultiplier { get; set; }
 
         [JsonProperty("manufacturerCode")]
         public string ManufacturerCode { get; set; }
@@ -680,7 +680,7 @@ namespace ReviewsRatings.Models
         public object Description { get; set; }
 
         [JsonProperty("unitMultiplier")]
-        public long UnitMultiplier { get; set; }
+        public long? UnitMultiplier { get; set; }
     }
 
     public class Content
@@ -1249,7 +1249,7 @@ namespace ReviewsRatings.Models
         public long Price { get; set; }
 
         [JsonProperty("unitMultiplier")]
-        public long UnitMultiplier { get; set; }
+        public long? UnitMultiplier { get; set; }
     }
 
     public partial class Receipt

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -75,7 +75,7 @@ type Query {
     to: Int = 9
     orderBy: String
     status: String
-  ): ReviewsResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  ): ReviewsResult @cacheControl(scope: SEGMENT, maxAge: SHORT)
   averageRatingByProductId(productId: String!): Float
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
   totalReviewsByProductId(productId: String!): Int
@@ -86,7 +86,7 @@ type Query {
     to: Int = 9
     orderBy: String
     status: String
-  ): ReviewsResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  ): ReviewsResult @cacheControl(scope: SEGMENT, maxAge: SHORT)
   reviewByreviewDateTime(
     reviewDateTime: String!
     from: Int = 0

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -106,7 +106,7 @@ type Query {
   ): ReviewsResult @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   hasShopperReviewed(shopperId: String!, productId: String!): Boolean
     @cacheControl(scope: PRIVATE)
-  appSettings: AppSettings @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  appSettings: AppSettings
   verifySchema: String @cacheControl(scope: PUBLIC, maxAge: SHORT)
   migrateData: String @cacheControl(scope: PUBLIC, maxAge: SHORT)
   verifyMigration: String @cacheControl(scope: PUBLIC, maxAge: SHORT)

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -58,14 +58,14 @@ type AppSettings {
 }
 
 type Query {
-  review(id: ID!): Review
+  review(id: ID!): Review @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   reviews(
     searchTerm: String
     from: Int = 0
     to: Int = 9
     orderBy: String
     status: String
-  ): ReviewsResult
+  ): ReviewsResult @cacheControl(scope: PRIVATE)
   reviewsByProductId(
     productId: String!
     rating: Int
@@ -75,16 +75,18 @@ type Query {
     to: Int = 9
     orderBy: String
     status: String
-  ): ReviewsResult
+  ): ReviewsResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
   averageRatingByProductId(productId: String!): Float
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
   totalReviewsByProductId(productId: String!): Int
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
   reviewsByShopperId(
     shopperId: String!
     from: Int = 0
     to: Int = 9
     orderBy: String
     status: String
-  ): ReviewsResult
+  ): ReviewsResult @cacheControl(scope: PUBLIC, maxAge: SHORT)
   reviewByreviewDateTime(
     reviewDateTime: String!
     from: Int = 0
@@ -92,20 +94,23 @@ type Query {
     orderBy: String
     status: String
   ): ReviewsResult
-    @deprecated(reason: "This query was deprecated, please use reviewByDateRange instead.")
+    @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
+    @deprecated(
+      reason: "This query was deprecated, please use reviewByDateRange instead."
+    )
   reviewByDateRange(
     fromDate: String!
     toDate: String!
     orderBy: String
     status: String
-  ): ReviewsResult
+  ): ReviewsResult @cacheControl(scope: PUBLIC, maxAge: MEDIUM)
   hasShopperReviewed(shopperId: String!, productId: String!): Boolean
     @cacheControl(scope: PRIVATE)
-  appSettings: AppSettings
-  verifySchema: String
-  migrateData: String
-  verifyMigration: String
-  successfulMigration: String
+  appSettings: AppSettings @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  verifySchema: String @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  migrateData: String @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  verifyMigration: String @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  successfulMigration: String @cacheControl(scope: PUBLIC, maxAge: SHORT)
 }
 
 # Mutations
@@ -136,7 +141,9 @@ input EditReviewInput {
 
 type Mutation {
   newReview(review: ReviewInput!): Review
-  editReview(id: String!, review: EditReviewInput!): Review @cacheControl(scope: PRIVATE)
+  editReview(id: String!, review: EditReviewInput!): Review
+    @cacheControl(scope: PRIVATE)
   deleteReview(ids: [String!]): Boolean @cacheControl(scope: PRIVATE)
-  moderateReview(ids: [String!], approved: Boolean!): Boolean @cacheControl(scope: PRIVATE)
+  moderateReview(ids: [String!], approved: Boolean!): Boolean
+    @cacheControl(scope: PRIVATE)
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -77,9 +77,9 @@ type Query {
     status: String
   ): ReviewsResult @cacheControl(scope: PRIVATE)
   averageRatingByProductId(productId: String!): Float
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PUBLIC, maxAge: 30)
   totalReviewsByProductId(productId: String!): Int
-    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @cacheControl(scope: PUBLIC, maxAge: 30)
   reviewsByShopperId(
     shopperId: String!
     from: Int = 0

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -75,7 +75,7 @@ type Query {
     to: Int = 9
     orderBy: String
     status: String
-  ): ReviewsResult @cacheControl(scope: SEGMENT, maxAge: SHORT)
+  ): ReviewsResult @cacheControl(scope: PRIVATE)
   averageRatingByProductId(productId: String!): Float
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
   totalReviewsByProductId(productId: String!): Int

--- a/react/RatingInline.tsx
+++ b/react/RatingInline.tsx
@@ -145,6 +145,7 @@ function RatingInline() {
     client
       .query({
         query: AppSettings,
+        fetchPolicy: 'network-only',
       })
       .then((response: ApolloQueryResult<SettingsData>) => {
         const settings = response.data.appSettings

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -158,7 +158,6 @@ function RatingSummary() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
-    ssr: false,
   })
 
   const {
@@ -171,7 +170,6 @@ function RatingSummary() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
-    ssr: false,
   })
 
   useEffect(() => {

--- a/react/RatingSummary.tsx
+++ b/react/RatingSummary.tsx
@@ -158,6 +158,7 @@ function RatingSummary() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
+    ssr: false,
   })
 
   const {
@@ -170,6 +171,7 @@ function RatingSummary() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
+    ssr: false,
   })
 
   useEffect(() => {

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -218,7 +218,7 @@ export function ReviewForm({
   refetchReviews,
 }: {
   settings?: Partial<AppSettings>
-  refetchReviews: any
+  refetchReviews: () => void
 }) {
   const client = useApolloClient()
   const intl = useIntl()

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -444,7 +444,6 @@ function Reviews() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
-    ssr: false,
   })
 
   const options = [
@@ -497,7 +496,6 @@ function Reviews() {
     client
       .query({
         query: getBindings,
-        variables: null,
       })
       .then((res: any) => {
         const list = res.data.tenantInfo.bindings.map((item: any) => {

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -585,7 +585,7 @@ function Reviews() {
       type: 'SET_AVERAGE',
       args: { average },
     })
-  }, [dataAverage, loadingAverage, state])
+  }, [dataAverage, loadingAverage, state.total, state.reviews])
 
   useEffect(() => {
     if (loadingReviews || !dataReviews) return

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -431,6 +431,7 @@ function Reviews() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
     ssr: false,
   })
 
@@ -444,6 +445,7 @@ function Reviews() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
     ssr: false,
   })
 
@@ -567,13 +569,23 @@ function Reviews() {
   useEffect(() => {
     if (loadingAverage || !dataAverage) return
 
-    const average = dataAverage.averageRatingByProductId
+    let average = dataAverage.averageRatingByProductId
+
+    if (state.total <= 10) {
+      const summedRating = state.reviews?.reduce(
+        (partialSum, a) => partialSum + a.rating,
+        0
+      )
+
+      average = summedRating ? summedRating / state.total : average
+      average = Math.round((average + Number.EPSILON) * 100) / 100 // limit to 2 decimal places
+    }
 
     dispatch({
       type: 'SET_AVERAGE',
       args: { average },
     })
-  }, [dataAverage, loadingAverage])
+  }, [dataAverage, loadingAverage, state])
 
   useEffect(() => {
     if (loadingReviews || !dataReviews) return
@@ -611,6 +623,11 @@ function Reviews() {
     state.settings.defaultOpenCount,
     refetchAverage,
   ])
+
+  const handleRefetch = () => {
+    refetchAverage()
+    refetchReviews()
+  }
 
   const baseUrl = getBaseUrl()
 
@@ -680,7 +697,7 @@ function Reviews() {
           >
             <ReviewForm
               settings={state.settings}
-              refetchReviews={refetchReviews}
+              refetchReviews={handleRefetch}
             />
           </Collapsible>
         ) : (

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -444,6 +444,7 @@ function Reviews() {
     },
     skip: !productId,
     fetchPolicy: 'network-only',
+    ssr: false,
   })
 
   const options = [

--- a/react/admin/components/DownloadTable.tsx
+++ b/react/admin/components/DownloadTable.tsx
@@ -70,7 +70,7 @@ export const DownloadTable: FC<DownloadTableProps> = ({
           : 'SearchDate:desc',
       }}
       notifyOnNetworkStatusChange
-      fetchPolicy="cache-and-network"
+      fetchPolicy="network-only"
     >
       {({ loading, error, data, networkStatus }) => {
         if (data?.reviews?.range) {

--- a/react/admin/components/ReviewsTable.tsx
+++ b/react/admin/components/ReviewsTable.tsx
@@ -120,7 +120,7 @@ export const ReviewsTable: FC<ReviewsTableProps> = ({
           : 'SearchDate:desc',
       }}
       notifyOnNetworkStatusChange
-      fetchPolicy="cache-and-network"
+      fetchPolicy="network-only"
     >
       {({ loading, error, data, fetchMore, networkStatus, variables }) => {
         if (data?.reviews?.range) {


### PR DESCRIPTION
#### What problem is this solving?

The previous GraphQL cache configuration was resulting in poor UX in the reviews admin. For example, if the user approved a review, it might not appear in the Approved Reviews tab immediately, and could actually continue to appear under the Pending tab, leading to confusion. 

This PR adds an appropriate amount of caching to each GraphQL query, and adjusts the admin queries to use a "network-only" fetch policy.

#### How to test it?

Linked here: https://arthur--sandboxusdev.myvtex.com/admin/reviews-ratings/pending/

Approving one of the pending reviews should now cause it to immediately appear in the Approved tab.