### PR TITLE
[REVIEWS-120] GraphQL and VerifySchema improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added GraphQL provider to queries and mutations
+- Added additional VerifySchema checks
+- VerifySchema now uses the app's token to authenticate
+- Added error log if app is unable to search MasterData
+
 ## [3.11.0] - 2022-09-14
 
 ### Fixed

--- a/dotnet/Controllers/RoutesController.cs
+++ b/dotnet/Controllers/RoutesController.cs
@@ -203,7 +203,6 @@ namespace ReviewsRatings.Controllers
                         ids = new string[1];
                         ids[0] = id;
                         return Json(await this._productReviewsService.DeleteReview(ids));
-                        break;
                     case REVIEWS:
                         if (!keyAndTokenValid)
                         {
@@ -213,7 +212,6 @@ namespace ReviewsRatings.Controllers
                         string bodyAsText = await new System.IO.StreamReader(HttpContext.Request.Body).ReadToEndAsync();
                         ids = JsonConvert.DeserializeObject<string[]>(bodyAsText);
                         return Json(await this._productReviewsService.DeleteReview(ids));
-                        break;
                 }
             }
             else if ("patch".Equals(HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase))
@@ -230,7 +228,6 @@ namespace ReviewsRatings.Controllers
                         Review review = JsonConvert.DeserializeObject<Review>(bodyAsText);
                         review.Id = id;
                         return Json(await this._productReviewsService.EditReview(review));
-                        break;
                 }
             }
             else if ("get".Equals(HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase))
@@ -259,7 +256,6 @@ namespace ReviewsRatings.Controllers
 
                         Review review = await this._productReviewsService.GetReview(id);
                         return Json(review);
-                        break;
                     case REVIEWS:
                         IList<Review> reviews;
                         if (!string.IsNullOrEmpty(ratingQS))
@@ -296,7 +292,6 @@ namespace ReviewsRatings.Controllers
                         };
 
                         return Json(searchResponse);
-                        break;
                     case RATING:
                         decimal average = await _productReviewsService.GetAverageRatingByProductId(id);
                         wrapper = await _productReviewsService.GetReviewsByProductId(id);

--- a/dotnet/GraphQL/Query.cs
+++ b/dotnet/GraphQL/Query.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace ReviewsRatings.GraphQL
 {
@@ -114,7 +115,7 @@ namespace ReviewsRatings.GraphQL
                 {
                     int count = 0;
                     var searchResult = await productReviewService.GetReviewsByProductId(context.GetArgument<string>("productId"));
-                    if (searchResult != null && searchResult.Reviews.Count > 0)
+                    if (searchResult != null && searchResult.Reviews != null && searchResult.Reviews.Count > 0)
                     {
                         count = searchResult.Reviews.Count;
                         AppSettings appSettings = await productReviewService.GetAppSettings();

--- a/dotnet/Services/ProductReviewService.cs
+++ b/dotnet/Services/ProductReviewService.cs
@@ -346,9 +346,11 @@
                 {
                     _context.Vtex.Logger.Info("GetReviewsByProductId", null, $"Getting reviews", new[] { ("productId", productId), ("Total", wrapper.Range.Total.ToString()) });
                 }
+
             }
             catch (Exception ex)
             {
+
                 _context.Vtex.Logger.Error("GetReviewsByProductId", null, 
                 "Error:", ex,
                 new[]
@@ -872,7 +874,6 @@
             }
 
             review.Id = maxKeyValue;
-            Console.WriteLine($"MAX KEY VALUE = {maxKeyValue}");
 
             IList<LegacyReview> reviews = await this._productReviewRepository.GetProductReviewsAsync(review.ProductId);
             if(reviews == null)

--- a/graphql/averageRatingByProductId.graphql
+++ b/graphql/averageRatingByProductId.graphql
@@ -1,3 +1,4 @@
 query AverageRatingByProductId($productId: String!) {
-    averageRatingByProductId(productId: $productId) 
+  averageRatingByProductId(productId: $productId)
+    @context(provider: "vtex.reviews-and-ratings")
 }

--- a/graphql/deleteReview.graphql
+++ b/graphql/deleteReview.graphql
@@ -1,3 +1,3 @@
 mutation DeleteReview($ids: [String!]) {
-  deleteReview(ids: $ids)
+  deleteReview(ids: $ids) @context(provider: "vtex.reviews-and-ratings")
 }

--- a/graphql/editReview.graphql
+++ b/graphql/editReview.graphql
@@ -1,5 +1,6 @@
 mutation EditReview($id: String!, $review: EditReviewInput!) {
-  editReview(id: $id, review: $review) {
+  editReview(id: $id, review: $review)
+    @context(provider: "vtex.reviews-and-ratings") {
     id
     productId
     rating

--- a/graphql/hasShopperReviewed.graphql
+++ b/graphql/hasShopperReviewed.graphql
@@ -1,3 +1,4 @@
 query HasShopperReviewed($shopperId: String!, $productId: String!) {
-    hasShopperReviewed(shopperId: $shopperId, productId: $productId)
+  hasShopperReviewed(shopperId: $shopperId, productId: $productId)
+    @context(provider: "vtex.reviews-and-ratings")
 }

--- a/graphql/moderateReview.graphql
+++ b/graphql/moderateReview.graphql
@@ -1,3 +1,4 @@
 mutation ModerateReview($ids: [String!], $approved: Boolean!) {
   moderateReview(ids: $ids, approved: $approved)
+    @context(provider: "vtex.reviews-and-ratings")
 }

--- a/graphql/newReview.graphql
+++ b/graphql/newReview.graphql
@@ -1,5 +1,5 @@
 mutation NewReview($review: ReviewInput!) {
-  newReview(review: $review) {
+  newReview(review: $review) @context(provider: "vtex.reviews-and-ratings") {
     id
     productId
     rating

--- a/graphql/review.graphql
+++ b/graphql/review.graphql
@@ -1,5 +1,5 @@
 query Review($id: ID!) {
-  review(id: $id) {
+  review(id: $id) @context(provider: "vtex.reviews-and-ratings") {
     id
     productId
     rating

--- a/graphql/reviewByDateRange.graphql
+++ b/graphql/reviewByDateRange.graphql
@@ -3,7 +3,8 @@ query ReviewByDateRange(
   $toDate: String!
   $orderBy: String
 ) {
-  reviewByDateRange(fromDate: $fromDate, toDate: $toDate, orderBy: $orderBy) {
+  reviewByDateRange(fromDate: $fromDate, toDate: $toDate, orderBy: $orderBy)
+    @context(provider: "vtex.reviews-and-ratings") {
     data {
       id
       productId

--- a/graphql/reviewByreviewDateTime.graphql
+++ b/graphql/reviewByreviewDateTime.graphql
@@ -4,12 +4,12 @@ query ReviewByreviewDateTime(
   $to: Int
   $orderBy: String
   $status: String
-) {
+) @context(provider: "vtex.reviews-and-ratings") {
   reviewByreviewDateTime(
     reviewDateTime: $reviewDateTime
-    from: $from,
-    to: $to,
-    orderBy: $orderBy,
+    from: $from
+    to: $to
+    orderBy: $orderBy
     status: $status
   ) {
     data {

--- a/graphql/reviews.graphql
+++ b/graphql/reviews.graphql
@@ -4,7 +4,7 @@ query Reviews(
   $to: Int
   $orderBy: String
   $status: String
-) {
+) @context(provider: "vtex.reviews-and-ratings") {
   reviews(
     searchTerm: $searchTerm
     from: $from

--- a/graphql/reviewsByProductId.graphql
+++ b/graphql/reviewsByProductId.graphql
@@ -7,7 +7,7 @@ query ReviewsByProductId(
   $to: Int
   $orderBy: String
   $status: String
-) {
+) @context(provider: "vtex.reviews-and-ratings") {
   reviewsByProductId(
     productId: $productId
     rating: $rating

--- a/graphql/reviewsByShopperId.graphql
+++ b/graphql/reviewsByShopperId.graphql
@@ -9,7 +9,7 @@ query ReviewsByShopperId(
     offset: $offset
     limit: $limit
     orderBy: $orderBy
-  ) {
+  ) @context(provider: "vtex.reviews-and-ratings") {
     id
     productId
     rating

--- a/graphql/totalReviewsByProductId.graphql
+++ b/graphql/totalReviewsByProductId.graphql
@@ -1,3 +1,4 @@
 query TotalReviewsByProductId($productId: String!) {
-    totalReviewsByProductId(productId: $productId) 
+  totalReviewsByProductId(productId: $productId)
+    @context(provider: "vtex.reviews-and-ratings")
 }


### PR DESCRIPTION
#### What problem is this solving?

App is unable to create MasterData schema in some cases, and this error has poor visibility.

This PR improves several things:
- calls `VerifySchema()` more often
- uses the app's auth token to authenticate the `VerifySchema()` API requests (and any other requests to VBASE or MD)
- logs an error if the app doesn't get a successful response when performing an MD search
- adds the `@context(provider: '...')` directive to all queries and mutations

#### How to test it?

Linked here: https://vta--vta.myvtex.com/admin/reviews-ratings/pending/

Previously, no reviews were showing up in the admin because the MD schema had not been applied.
