### PR TITLE
adding intecept for average rating fix

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -102,7 +102,14 @@ Cypress.Commands.add('getAverageRating', (user, product, validate = true) => {
     cy.openProduct(product, true)
   }
 
-  cy.get('span[class*=average]').should('not.contain', '0')
+  cy.getVtexItems().then(vtex => {
+    cy.intercept({
+      url: `${vtex.baseUrl}/**`,
+      query: { operationName: 'AverageRatingByProductId' },
+    }).as('AverageRatingByProductId')
+    cy.get('span[class*=average]').should('not.contain', '0')
+    cy.wait('@AverageRatingByProductId')
+  })
 
   cy.get('span[class*=average]', { timeout: 40000 })
     .invoke('text')


### PR DESCRIPTION
#### What problem is this solving?

There is an issue in verifying the average ratings in 2.1.3 test case. We have added intercept for averageRatingsByProductId query. It should work fine now. 

**[Cypress dashboard error link](https://dashboard.cypress.io/projects/964exx/runs/195/overview)** 
**App version**: 3.11.1

#### How to test it?

[workspace](https://reviewsandratings3923653--productusqa.myvtex.com/)
