### PR TITLE
[REVIEWS-122] Add GTM event for submitted reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Custom GTM dataLayer event for when user submits a review
+
 ## [3.11.2] - 2022-10-20
 
 ### Changed

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -11,6 +11,7 @@ import NewReview from '../graphql/newReview.graphql'
 import HasShopperReviewed from '../graphql/hasShopperReviewed.graphql'
 import StarPicker from './components/StarPicker'
 import { eventBus } from './utils/eventBus'
+import push from './utils/gtmPush'
 
 interface AppSettings {
   allowAnonymousReviews: boolean
@@ -398,6 +399,12 @@ export function ReviewForm({
         })
         .then(res => {
           if (res.data.newReview.id) {
+            // send review submitted event to GTM
+            push({
+              event: 'reviewSubmitted',
+              productId,
+              rating: state.rating,
+            })
             setTimeout(() => {
               if (
                 !settings?.requireApproval &&

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -17,6 +17,7 @@ declare global {
   interface Window extends Window {
     __RENDER_8_SESSION__: RenderSession
     __RUNTIME__: Runtime
+    dataLayer: any[]
   }
 
   interface RenderSession {

--- a/react/utils/gtmPush.ts
+++ b/react/utils/gtmPush.ts
@@ -1,0 +1,5 @@
+window.dataLayer = window?.dataLayer || []
+
+export default function push(event: Record<string, unknown>) {
+  window.dataLayer.push(event)
+}


### PR DESCRIPTION
#### What problem is this solving?

This PR adds a custom GTM event to enable tracking of review submissions, following [these instructions](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-sending-custom-events-to-google-tag-manager).

This PR can be used as an example for adding additional events as needed.

#### How to test it?

Linked here: https://arthur--sandboxusdev.myvtex.com/

After submitting a review, run `window.dataLayer` in the browser console and the custom event should be shown in the array.