### PR TITLE
[REVIEWS-128] Fixed pdp stars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed review stars laoding
+
 ## [3.12.1] - 2022-12-05
 
 ### Added

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -631,6 +631,7 @@ function Reviews() {
     refetchAverage()
   }, [
     dataReviews,
+    dataAverage,
     loadingReviews,
     state.settings.defaultOpenCount,
     refetchAverage,


### PR DESCRIPTION
#### What problem is this solving?

PDP review stars are not showing at the first load 
<img width="883" alt="Screenshot 2022-12-15 at 3 44 30 PM" src="https://user-images.githubusercontent.com/92704360/207963292-052c71cf-9909-4119-9896-75fadd414f3e.png">


#### How to test it?

Use Incognito mode to open link
[https://esika.tiendabelcorp.cl/vibranza-perfume-de-mujer-45-ml/p?workspace=aurora](https://esika.tiendabelcorp.cl/vibranza-perfume-de-mujer-45-ml/p?workspace=aurora)
you should see all the stars showing 
