### PR TITLE
[REVIEWS-134] fix review state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed review state dispatch & improve GetAverageRatingByProductId loading time
+
 ## [3.12.3] - 2022-12-22
 
 ## [3.12.2] - 2022-12-19

--- a/dotnet/Services/ProductReviewService.cs
+++ b/dotnet/Services/ProductReviewService.cs
@@ -137,19 +137,16 @@
             if (reviews != null)
             {
                 decimal totalRating = 0;
-
+                numberOfReviews = reviews.Count;
+                
                 foreach(Review review in reviews)
                 {
-                    if (review.Rating != null && review.Rating >= 0.00 && review.Rating <= 5.00)
-                    {
-                        totalRating = totalRating + review.Rating ?? 0;
-                        numberOfReviews++;
-                        if (review.Rating == 5) stars5++;
-                        else if (review.Rating == 4) stars4++;
-                        else if (review.Rating == 3) stars3++;
-                        else if (review.Rating == 2) stars2++;
-                        else stars1++;
-                    }
+                    totalRating = totalRating + review.Rating ?? 0;
+                    if (review.Rating >= 5.00) stars5++;
+                    else if (review.Rating == 4) stars4++;
+                    else if (review.Rating == 3) stars3++;
+                    else if (review.Rating == 2) stars2++;
+                    else stars1++;
                 }
                 if (numberOfReviews != 0)
                 {

--- a/react/Reviews.tsx
+++ b/react/Reviews.tsx
@@ -106,8 +106,9 @@ type ReducerActions =
   | { type: 'SET_PASTREVIEWS'; args: { pastReviews: boolean } }
   | {
       type: 'SET_REVIEWS'
-      args: { reviews: Review[]; total: number; graphArray: number[] }
+      args: { reviews: Review[]; total: number }
     }
+  | { type: 'SET_REVIEW_STATE'; args: { graphArray: number[] } }
   | { type: 'SET_TOTAL'; args: { total: number } }
   | { type: 'SET_AVERAGE'; args: { average: number } }
   | { type: 'SET_SETTINGS'; args: { settings: AppSettings } }
@@ -184,8 +185,13 @@ const reducer = (state: State, action: ReducerActions) => {
         ...state,
         reviews: action.args.reviews || [],
         total: action.args.total,
-        reviewsStats: action.args.graphArray || [],
         hasTotal: true,
+      }
+
+    case 'SET_REVIEW_STATE':
+      return {
+        ...state,
+        reviewsStats: action.args.graphArray || [],
       }
 
     case 'SET_TOTAL':
@@ -599,24 +605,30 @@ function Reviews() {
   }, [dataAverage, loadingAverage, state.total, state.reviews])
 
   useEffect(() => {
+    if (loadingAverage || !dataAverage) return
+
+    const graphArray = [0, 0, 0, 0, 0, 0]
+    graphArray[0] = dataAverage.averageRatingByProductId.total
+    graphArray[1] = dataAverage.averageRatingByProductId.starsOne
+    graphArray[2] = dataAverage.averageRatingByProductId.starsTwo
+    graphArray[3] = dataAverage.averageRatingByProductId.starsThree
+    graphArray[4] = dataAverage.averageRatingByProductId.starsFour
+    graphArray[5] = dataAverage.averageRatingByProductId.starsFive
+
+    dispatch({
+      type: 'SET_REVIEW_STATE',
+      args: { graphArray },
+    })
+  }, [dataAverage, loadingAverage, state.total, state.reviews])
+
+  useEffect(() => {
     if (loadingReviews || !dataReviews) return
     const reviews = dataReviews.reviewsByProductId.data
     const { total } = dataReviews.reviewsByProductId.range
-    const graphArray = [0, 0, 0, 0, 0, 0]
-
-    graphArray[0] = total
-    if (dataAverage) {
-      graphArray[0] = dataAverage.averageRatingByProductId.total
-      graphArray[1] = dataAverage.averageRatingByProductId.starsOne
-      graphArray[2] = dataAverage.averageRatingByProductId.starsTwo
-      graphArray[3] = dataAverage.averageRatingByProductId.starsThree
-      graphArray[4] = dataAverage.averageRatingByProductId.starsFour
-      graphArray[5] = dataAverage.averageRatingByProductId.starsFive
-    }
 
     dispatch({
       type: 'SET_REVIEWS',
-      args: { reviews, total, graphArray },
+      args: { reviews, total },
     })
 
     const defaultOpenCount = Math.min(state.settings.defaultOpenCount, total)
@@ -627,15 +639,7 @@ function Reviews() {
         reviewNumbers: [...Array(defaultOpenCount).keys()],
       },
     })
-
-    refetchAverage()
-  }, [
-    dataReviews,
-    dataAverage,
-    loadingReviews,
-    state.settings.defaultOpenCount,
-    refetchAverage,
-  ])
+  }, [dataReviews, loadingReviews, state.settings.defaultOpenCount])
 
   const handleRefetch = () => {
     refetchAverage()


### PR DESCRIPTION
What problem is this solving?

the previous fix about loading star causing infinite request, this PR fix both the infinite request and the PDP loading star problem. Also improved GetAverageRatingByProductId query.

How to test it?

Use Incognito mode to open link
https://esika.tiendabelcorp.cl/vibranza-perfume-de-mujer-45-ml/p?workspace=aurora111
you should see all the stars showing

open any review page to see the requests