### PR TITLE
[REVIEW-129] fix searchDate parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed addSeachDate function about parsing reviewDateTime
+
 ## [3.12.4] - 2023-01-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+
 - Fixed addSeachDate function about parsing reviewDateTime
+
+### Fixed
+
 - Fixed context provider error on the get review query
 
 ## [3.12.4] - 2023-01-03

--- a/dotnet/DataSources/ProductReviewRepository.cs
+++ b/dotnet/DataSources/ProductReviewRepository.cs
@@ -805,7 +805,9 @@
             if (string.IsNullOrEmpty(review.SearchDate))
             {
                 DateTime dtSearchDate;
-                if(!DateTime.TryParse(review.ReviewDateTime, out dtSearchDate))
+                DateTime.TryParse(review.ReviewDateTime, out dtSearchDate);
+
+                if(dtSearchDate == DateTime.MinValue)
                 {
                     DateTime? dtSearchDateParsed = this.ParseReviewDate(review.ReviewDateTime);
                     dtSearchDate = dtSearchDateParsed ?? DateTime.Now;


### PR DESCRIPTION
#### What problem is this solving?

There was a parsing problem of the searchDate which used to sort by the date of reviews.

#### How to test it?

[Workspace](https://aurora--sandboxusdev.myvtex.com/admin/reviews-ratings/pending)

API : https://aurora--sandboxusdev.myvtex.com/reviews-and-ratings/add-search-date

#### Screenshots or example usage:

