### PR TITLE
Removes store-graphql dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Removed store-graphql dependency
+
 ## [3.12.4] - 2023-01-03
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,6 @@
     "vtex.product-context": "0.x",
     "vtex.store": "2.x",
     "vtex.search-graphql": "0.x",
-    "vtex.store-graphql": "2.x",
     "vtex.tenant-graphql": "0.x",
     "vtex.channels-components": "4.x",
     "vtex.paginated-table": "0.x",
@@ -33,9 +32,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "Reviews and Ratings",
@@ -69,32 +66,14 @@
         "title": "Review default stars",
         "description": "Specified review default stars on product page",
         "type": "string",
-        "enum": [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5"
-        ],
+        "enum": ["1", "2", "3", "4", "5"],
         "default": "5"
       },
       "defaultOpenCount": {
         "title": "Number of open review accordions",
         "description": "Specified number of review tabs on product page will default to open",
         "type": "string",
-        "enum": [
-          "0",
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10"
-        ],
+        "enum": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
         "default": "0"
       },
       "showGraph": {

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -6,7 +6,6 @@ import { FormattedMessage, defineMessages, useIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { Card, Input, Button, Textarea } from 'vtex.styleguide'
 
-import getOrders from './queries/orders.graphql'
 import NewReview from '../graphql/newReview.graphql'
 import HasShopperReviewed from '../graphql/hasShopperReviewed.graphql'
 import StarPicker from './components/StarPicker'
@@ -37,7 +36,6 @@ interface State {
   userAuthenticated: boolean
   alreadySubmitted: boolean
   isSubmitting: boolean
-  verifiedPurchaser: boolean
   validation: Validation
   showValidationErrors: boolean
 }
@@ -58,7 +56,6 @@ type ReducerActions =
   | { type: 'SET_NAME'; args: { name: string } }
   | { type: 'SET_ID'; args: { id: string } }
   | { type: 'SET_AUTHENTICATED'; args: { authenticated: boolean } }
-  | { type: 'SET_VERIFIED' }
   | { type: 'SET_ALREADY_SUBMITTED'; args: { alreadySubmitted: boolean } }
   | { type: 'SET_SUBMITTED' }
   | { type: 'SET_SUBMITTING'; args: { isSubmitting: boolean } }
@@ -141,12 +138,6 @@ const reducer = (state: State, action: ReducerActions) => {
       return {
         ...state,
         userAuthenticated: true,
-      }
-
-    case 'SET_VERIFIED':
-      return {
-        ...state,
-        verifiedPurchaser: true,
       }
 
     case 'SET_ALREADY_SUBMITTED':
@@ -239,7 +230,6 @@ export function ReviewForm({
     shopperId: '',
     reviewSubmitted: false,
     alreadySubmitted: false,
-    verifiedPurchaser: false,
     userAuthenticated: false,
     validation: {
       hasTitle: false,
@@ -325,31 +315,6 @@ export function ReviewForm({
               type: 'SET_ALREADY_SUBMITTED',
               args: { alreadySubmitted: result.data.hasShopperReviewed },
             })
-          }
-        })
-
-      client
-        .query({
-          query: getOrders,
-          variables: null,
-        })
-        .then((res: any) => {
-          // eslint-disable-next-line vtex/prefer-early-return
-          if (res?.data?.orders && res.data.orders.length) {
-            const hasItem = !!res.data.orders.find((order: any) => {
-              return (
-                !!order.isCompleted &&
-                !!order.items.find((item: any) => {
-                  return item.productId === productId
-                })
-              )
-            })
-
-            if (hasItem) {
-              dispatch({
-                type: 'SET_VERIFIED',
-              })
-            }
           }
         })
     })

--- a/react/package.json
+++ b/react/package.json
@@ -38,7 +38,6 @@
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
     "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.50.0/public/@types/vtex.search-graphql",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.127.0/public/@types/vtex.store",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.155.28/public/@types/vtex.store-graphql",
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"
   },
   "version": "3.12.4"

--- a/react/queries/orders.graphql
+++ b/react/queries/orders.graphql
@@ -1,8 +1,0 @@
-query {
-  orders @context(provider: "vtex.store-graphql") {
-    isCompleted
-    items {
-      productId
-    }
-  }
-}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5305,10 +5305,6 @@ verror@1.10.0:
   version "0.50.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.50.0/public/@types/vtex.search-graphql#e29e418461f338165a1f4ddaf2ed0fd2e7246420"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.155.28/public/@types/vtex.store-graphql":
-  version "2.155.28"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.155.28/public/@types/vtex.store-graphql#a47c90088f17ac6f519911048d2b6e00bc0fba2b"
-
 "vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.127.0/public/@types/vtex.store":
   version "2.127.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.127.0/public/@types/vtex.store#d78eafaef1ea6f4e87cbc7adc869bff44e437329"


### PR DESCRIPTION
#### What problem is this solving?

The `store-graphql` orders query uses a deprecated API, and we need to remove all usage of it to shut down the endpoint. We found out that the reviews-and-ratings use this query to fetch the user orders in the `ReviewForm` component.

The goal of this fetch was to set the `verifiedPurchaser` state on the form, but this attribute is not used anymore. So we simply removed the call to the API and all related code to this attribute.

#### How to test it?
Log in and add a review to any item. The process should work with no problem
[Workspace](https://storetheme.vtex.com/?workspace=danzan)
