### PR TITLE
Removes store-graphql dependency for major 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed store-graphql dependency
+
 ## [2.12.7] - 2023-01-02
 
 ### Fixed
@@ -13,23 +17,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Portuguese translations.
 
 ## [2.12.6] - 2022-01-13
+
 ### Changed
+
 - Use product's URI as @id on `Product` schema for `RatingSummary` and `Reviews` blocks.
 
 ## [2.12.4] - 2021-09-24
 
 ## [2.11.2] - 2021-09-24
+
 ### Added
+
 - Use short cache on GraphQL queries
 
 ## [2.11.1] - 2021-09-24
+
 ### Fixed
+
 - Used metric instead of log to improve efficiency
 - Loading reviews messages translated
 
 ## [2.11.0] - 2021-09-16
 
-### Added 
+### Added
 
 - I18n Bg and pseudo language to implement In Context tool.
 
@@ -53,7 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add setting to display stars in `product-rating-inline` block when the product has no reviews
-- Use locale to format review's date in account admin view 
+- Use locale to format review's date in account admin view
 
 ## [2.11.8] - 2021-08-30
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,6 @@
     "vtex.product-context": "0.x",
     "vtex.store": "2.x",
     "vtex.search-graphql": "0.x",
-    "vtex.store-graphql": "2.x",
     "vtex.channels-components": "4.x",
     "vtex.paginated-table": "0.x",
     "vtex.css-handles": "0.x"
@@ -32,9 +31,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "admin/reviews.reviewsandratings.title",
@@ -68,19 +65,7 @@
         "title": "admin/reviews.defaultOpenCount.tittle",
         "description": "admin/reviews.defaultOpenCount.description",
         "type": "string",
-        "enum": [
-          "0",
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10"
-        ],
+        "enum": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"],
         "default": "0"
       },
       "showGraph": {

--- a/react/ReviewForm.tsx
+++ b/react/ReviewForm.tsx
@@ -1,13 +1,12 @@
 /* eslint-disable no-console */
 import React, { Fragment, useEffect, useReducer } from 'react'
 import { useProduct } from 'vtex.product-context'
-import { ApolloQueryResult } from 'apollo-client'
+import type { ApolloQueryResult } from 'apollo-client'
 import { useApolloClient } from 'react-apollo'
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { Card, Input, Button, Textarea } from 'vtex.styleguide'
 
-import getOrders from './queries/orders.graphql'
 import NewReview from '../graphql/newReview.graphql'
 import HasShopperReviewed from '../graphql/hasShopperReviewed.graphql'
 import StarPicker from './components/StarPicker'
@@ -34,7 +33,6 @@ interface State {
   userAuthenticated: boolean
   alreadySubmitted: boolean
   isSubmitting: boolean
-  verifiedPurchaser: boolean
   validation: Validation
   showValidationErrors: boolean
 }
@@ -54,7 +52,6 @@ type ReducerActions =
   | { type: 'SET_NAME'; args: { name: string } }
   | { type: 'SET_ID'; args: { id: string } }
   | { type: 'SET_AUTHENTICATED'; args: { authenticated: boolean } }
-  | { type: 'SET_VERIFIED' }
   | { type: 'SET_ALREADY_SUBMITTED' }
   | { type: 'SET_SUBMITTED' }
   | { type: 'SET_SUBMITTING'; args: { isSubmitting: boolean } }
@@ -69,7 +66,6 @@ const initialState = {
   shopperId: '',
   reviewSubmitted: false,
   alreadySubmitted: false,
-  verifiedPurchaser: false,
   userAuthenticated: false,
   validation: {
     hasTitle: false,
@@ -88,6 +84,7 @@ const reducer = (state: State, action: ReducerActions) => {
         ...state,
         rating: action.args.rating,
       }
+
     case 'SET_TITLE':
       return {
         ...state,
@@ -97,6 +94,7 @@ const reducer = (state: State, action: ReducerActions) => {
           hasTitle: action.args.title !== '',
         },
       }
+
     case 'SET_TEXT':
       return {
         ...state,
@@ -106,11 +104,13 @@ const reducer = (state: State, action: ReducerActions) => {
           hasText: action.args.text !== '',
         },
       }
+
     case 'SET_LOCATION':
       return {
         ...state,
         location: action.args.location,
       }
+
     case 'SET_NAME':
       return {
         ...state,
@@ -120,6 +120,7 @@ const reducer = (state: State, action: ReducerActions) => {
           hasName: action.args.name !== '',
         },
       }
+
     case 'SET_ID':
       return {
         ...state,
@@ -130,36 +131,37 @@ const reducer = (state: State, action: ReducerActions) => {
             action.args.id.includes('@') && action.args.id.includes('.'),
         },
       }
+
     case 'SET_SUBMITTED':
       return {
         ...state,
         reviewSubmitted: true,
       }
+
     case 'SET_SUBMITTING':
       return {
         ...state,
         isSubmitting: action.args.isSubmitting,
       }
+
     case 'SET_AUTHENTICATED':
       return {
         ...state,
         userAuthenticated: true,
       }
-    case 'SET_VERIFIED':
-      return {
-        ...state,
-        verifiedPurchaser: true,
-      }
+
     case 'SET_ALREADY_SUBMITTED':
       return {
         ...state,
         alreadySubmitted: true,
       }
+
     case 'SHOW_VALIDATION':
       return {
         ...state,
         showValidationErrors: true,
       }
+
     default:
       return state
   }
@@ -277,30 +279,6 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
             })
           }
         })
-
-      client
-        .query({
-          query: getOrders,
-          variables: null,
-        })
-        .then((res: any) => {
-          // eslint-disable-next-line vtex/prefer-early-return
-          if (res?.data?.orders && res.data.orders.length) {
-            const hasItem = !!res.data.orders.find((order: any) => {
-              return (
-                !!order.isCompleted &&
-                !!order.items.find((item: any) => {
-                  return item.productId === productId
-                })
-              )
-            })
-            if (hasItem) {
-              dispatch({
-                type: 'SET_VERIFIED',
-              })
-            }
-          }
-        })
     })
   }, [client, productId])
 
@@ -323,6 +301,7 @@ export function ReviewForm({ settings }: { settings?: Partial<AppSettings> }) {
           }
         })
     }
+
     if (
       state.validation.hasName &&
       state.validation.hasTitle &&

--- a/react/package.json
+++ b/react/package.json
@@ -39,7 +39,6 @@
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime",
     "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.37.0/public/@types/vtex.search-graphql",
     "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.110.0/public/@types/vtex.store",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.136.9/public/@types/vtex.store-graphql",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.0/public/@types/vtex.styleguide"
   },
   "version": "2.12.7"

--- a/react/queries/orders.graphql
+++ b/react/queries/orders.graphql
@@ -1,8 +1,0 @@
-query {
-  orders @context(provider: "vtex.store-graphql") {
-    isCompleted
-    items {
-      productId
-    }
-  }
-}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4865,10 +4865,6 @@ verror@1.10.0:
   version "0.37.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.37.0/public/@types/vtex.search-graphql#c62dd40d8182ee14a554debeb31965d1b53a8783"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.136.9/public/@types/vtex.store-graphql":
-  version "2.136.9"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.136.9/public/@types/vtex.store-graphql#23cefbc32cfa03b02a053feb7c1a6e97cefa1c19"
-
 "vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.110.0/public/@types/vtex.store":
   version "2.110.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.110.0/public/@types/vtex.store#b6472e42914bbeaf805b9acf9137fe9302feecb4"


### PR DESCRIPTION
#### What problem is this solving?

This PR removes the `store-graphql` dependency as done at #236 for the latest major version.