### PR TITLE
Fix: add new ListOrders policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+### Added
+
+- Added ListOrders policy
+
 ### Added
 
 - For verifiedPurchaser testcase, added HasShopperReviewed intercept

--- a/manifest.json
+++ b/manifest.json
@@ -150,6 +150,9 @@
       "name": "OMSViewer"
     },
     {
+      "name": "ListOrders"
+    },
+    {
       "name": "Get_Account_By_Identifier"
     },
     {


### PR DESCRIPTION
#### What problem is this solving?

Added ListOrders policy
Required by new version of OMS: https://vtex.slack.com/archives/C91LXBHLK/p1675291291484189