### PR TITLE
Remove infix wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- Prefix wildcard to query for locale at Master Data's ProductReviews
+
 ## [3.13.2] - 2023-08-09
 
 ### Added

--- a/dotnet/Services/ProductReviewService.cs
+++ b/dotnet/Services/ProductReviewService.cs
@@ -419,7 +419,7 @@
                     {
                         searchQuery = $" AND approved=true";
                     }
-                    localeQuery = $"((locale=*{locale}-*) OR (locale is null))";
+                    localeQuery = $"((locale={locale}-*) OR (locale is null))";
                     if (ratingFilter)
                     {
                         ratingQuery = $" AND rating={rating}";
@@ -440,7 +440,7 @@
                     }
                     if (!string.IsNullOrEmpty(locale))
                     {
-                        localeQuery = $"&locale=*{locale}-*";
+                        localeQuery = $"&locale={locale}-*";
                     }
 
                     wrapper = await this._productReviewRepository.GetProductReviewsMD($"productId={productId}{sort}{searchQuery}{ratingQuery}{localeQuery}", from.ToString(), to.ToString());


### PR DESCRIPTION
#### What problem is this solving?

This app currently represents ~78% of wildcard queries at Master Data and it uses inffix `*{value}*` queries unnecessarily. Suffix wildcards are less expensive to calculate.

