### PR TITLE
Add &

### DIFF
--- a/dotnet/Services/ProductReviewService.cs
+++ b/dotnet/Services/ProductReviewService.cs
@@ -450,7 +450,7 @@
                         searchQuery = $"{searchQuery}&approved=true";
                     }
 
-                    wrapper = await this._productReviewRepository.GetProductReviewsMD($"productId={productId}{sort}{searchQuery}{ratingQuery}{localeQuery}", from.ToString(), to.ToString());
+                    wrapper = await this._productReviewRepository.GetProductReviewsMD($"productId={productId}{sort}{searchQuery}{ratingQuery}&{localeQuery}", from.ToString(), to.ToString());
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
#### What problem is this solving?

`/api/dataentities/productReviews/search?_fields=_all&_schema=reviewsSchema&productId=4859308(locale=-*)` is missing a & before the locale query

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
